### PR TITLE
Fix html-blocks to be wrapped in some inlines

### DIFF
--- a/packages/html-blocks/index.js
+++ b/packages/html-blocks/index.js
@@ -1,5 +1,7 @@
 const visit = require('unist-util-visit')
 
+const inline = ['p', 'kbd', 'del', 'sup']
+
 function plugin () {
   return transformer
 }
@@ -10,10 +12,9 @@ function transformer (tree) {
 
 function visitor (node, index, parent) {
   let replacement
-
   if (!parent) return
 
-  if (parent.tagName !== 'p') {
+  if (!inline.includes(parent.tagName)) {
     replacement = {
       type: 'element',
       tagName: 'p',

--- a/test/fixtures/misc/html.html
+++ b/test/fixtures/misc/html.html
@@ -13,3 +13,4 @@ Html with various attributes.
 <p>&lt;</p>
 <p>And one with other stuff but no closing bracket:</p>
 <p>&lt; foo</p>
+<p>Make sure we don't put block elements inside inline elements when compiling inlines, e.g. kbd: <kbd>&#x3C;strong></kbd> doesn't break anything.</p>

--- a/test/fixtures/misc/html.txt
+++ b/test/fixtures/misc/html.txt
@@ -1,7 +1,7 @@
 
 <h1>Block level html</h1>
 
-Some inline <b>stuff<b>.  
+Some inline <b>stuff<b>.
 
 Now some <arbitrary>arbitrary tags</arbitrary>.
 
@@ -27,3 +27,4 @@ And one with other stuff but no closing bracket:
 
 < foo
 
+Make sure we don't put block elements inside inline elements when compiling inlines, e.g. kbd: ||<strong>|| doesn't break anything.


### PR DESCRIPTION
* e.g. `||<p>||` works as expected, it does `<kbd>&gt;p></kbd>` instead of `<kbd></kbd><p>&gt;p></p>`
* [x] needs tests