### PR TITLE
Documente les changements de urlize

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ http://google.fr
 
 https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov
 
-toot@gmail.com
+toto@gmail.com
 ```
 
 diff

--- a/README.md
+++ b/README.md
@@ -156,3 +156,28 @@ diff:
    </blockquote>
  </blockquote>
 ```
+
+## autourlize only for protocoled url and htmlchars
+
+input :
+
+```markdown
+www.google.fr
+
+http://google.fr
+
+https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov
+
+toot@gmail.com
+```
+
+diff
+
+```diff
+- <p><a href="http://www.google.fr">www.google.fr</a></p>
++ <p>www.google.fr</p>
+<p><a href="http://google.fr">http://google.fr</a></p>
+- <p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
++ <p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d&#39;Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
+- <p><a href="mailto:toto@gmail.com">toto@gmail.com</a></p>
++ <p>toto@gmail.com</p>

--- a/test/fixtures/zds/extensions/urlize.html
+++ b/test/fixtures/zds/extensions/urlize.html
@@ -1,13 +1,12 @@
 <h1>Test urlize</h1>
 <p><a href="http://www.google.fr">http://www.google.fr</a></p>
 <p><a href="https://www.google.fr">https://www.google.fr</a></p>
-<p><a href="http://www.google.fr">www.google.fr</a></p>
-<p><a href="http://google.fr">google.fr</a></p>
+<p>www.google.fr</p>
+<p>google.fr</p>
 <p><a href="http://www.google.fr">http://www.google.fr</a></p>
-<p><a href="mailto:toto@gmail.com">toto@gmail.com</a></p>
 <p>Voici mon super lien qui termine une phrase <a href="http://www.google.fr">http://www.google.fr</a>.</p>
-<p><a href="https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov">https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov</a></p>
-<p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
+<p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d'Alexandrov">https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov</a></p>
+<p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d&#39;Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
 <p>javascript:alert%28'Hello%20world!'%29</p>
 <p>vbscript:msgbox%28%22Hello%20world!%22%29</p>
 <p>livescript:alert%28'Hello%20world!'%29</p>

--- a/test/fixtures/zds/extensions/urlize.txt
+++ b/test/fixtures/zds/extensions/urlize.txt
@@ -11,8 +11,6 @@ google.fr
 
 <http://www.google.fr>
 
-toto@gmail.com
-
 Voici mon super lien qui termine une phrase http://www.google.fr.
 
 https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov

--- a/test/test.js
+++ b/test/test.js
@@ -1001,7 +1001,7 @@ describe('HTML rendering', function () {
         expect(renderFile()(filepath)).to.have.html(loadFixture(filepath))
       })
 
-      it.skip(`properly renders urlize.txt`, function () {
+      it(`properly renders urlize.txt`, function () {
         const filepath = `${dir}/urlize.txt`
         expect(renderFile()(filepath)).to.have.html(loadFixture(filepath))
       })


### PR DESCRIPTION
Le plugin urlize a bien changé entre pyzmarkdown et zmarkdown. 

J'ai documenté les choses telles qu'elles sont aujourd'hui afin de lancer la discussion.

amha : 

- l'absence de mailto est une régression
- ne pas urlizer google.com (ou www.google.com) est un comportement souhaitable
- la gestion des caractères spéciaux dans les urls est mal faite

