### PR TITLE
Change regression-1 because the test was incorrect.

### DIFF
--- a/packages/remark-custom-blocks/__tests__/fixtures/regression-1.expected.html
+++ b/packages/remark-custom-blocks/__tests__/fixtures/regression-1.expected.html
@@ -1,4 +1,3 @@
-<p>content before
-[[s]]
-|Not Block
-with content after</p>
+<p>content before</p>
+<div class="spoiler"><p>Block</p></div>
+<p>with content after</p>

--- a/packages/remark-custom-blocks/__tests__/fixtures/regression-1.fixture.md
+++ b/packages/remark-custom-blocks/__tests__/fixtures/regression-1.fixture.md
@@ -1,4 +1,4 @@
 content before
 [[s]]
-|Not Block
+|Block
 with content after

--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -27,8 +27,6 @@ entrypoints.forEach(entrypoint => {
   Object.keys(specs).forEach(name => {
     const spec = specs[name]
 
-    if (name === 'regression-1') return
-
     ava(name, t => {
       const {contents} = unified()
         .use(reParse)


### PR DESCRIPTION
On https://zestedesavoir.com,

```
content before
[[s]]
|Not Block
with content after
```

gives:

```
<p>content before</p>
<div class="spoiler"><p>Not Block</p></div>
<p>with content after</p>
```

So,the test *regression-1* should be changed to fix #49 