### PR TITLE
rebber blockquote

### DIFF
--- a/packages/rebber/__tests__/fixtures/blockquote.expected.tex
+++ b/packages/rebber/__tests__/fixtures/blockquote.expected.tex
@@ -1,8 +1,6 @@
 \begin{Quotation}{Anonymous}
 a quote
-\end{Quotation}
 
-\begin{Quotation}{Anonymous}
 a
 multiline
 quote

--- a/packages/rebber/__tests__/fixtures/blockquote.expected.tex
+++ b/packages/rebber/__tests__/fixtures/blockquote.expected.tex
@@ -1,0 +1,7 @@
+\begin{Quotation}
+a quote
+\end{Quotation}
+
+\begin{Quotation}
+a multiline quote
+\end{Quotation}

--- a/packages/rebber/__tests__/fixtures/blockquote.expected.tex
+++ b/packages/rebber/__tests__/fixtures/blockquote.expected.tex
@@ -1,7 +1,9 @@
-\begin{Quotation}
+\begin{Quotation}{Anonymous}
 a quote
 \end{Quotation}
 
-\begin{Quotation}
-a multiline quote
+\begin{Quotation}{Anonymous}
+a
+multiline
+quote
 \end{Quotation}

--- a/packages/rebber/__tests__/fixtures/blockquote.fixture.md
+++ b/packages/rebber/__tests__/fixtures/blockquote.fixture.md
@@ -1,0 +1,5 @@
+> a quote
+
+> a 
+> multiline
+> quote

--- a/packages/rebber/__tests__/fixtures/blockquote.fixture.md
+++ b/packages/rebber/__tests__/fixtures/blockquote.fixture.md
@@ -1,5 +1,5 @@
 > a quote
 
-> a 
+> a
 > multiline
 > quote

--- a/packages/rebber/__tests__/index.js
+++ b/packages/rebber/__tests__/index.js
@@ -65,6 +65,16 @@ ava('inline-code', t => {
   t.deepEqual(contents.trim(), spec.expected.trim())
 })
 
+ava('blockquote', t => {
+  const spec = specs['blockquote']
+  const {contents} = unified()
+    .use(reParse)
+    .use(stringify)
+    .processSync(spec.fixture)
+
+  t.deepEqual(contents.trim(), spec.expected.trim())
+})
+
 Object.keys(specs).filter(Boolean).filter(name => name.startsWith('mix-')).forEach(name => {
   const spec = specs[name]
 

--- a/packages/rebber/src/one.js
+++ b/packages/rebber/src/one.js
@@ -17,6 +17,7 @@ handlers.strong = require('./types/strong')
 handlers.emphasis = require('./types/emphasis')
 handlers.delete = require('./types/delete')
 handlers.inlineCode = require('./types/inlinecode')
+handlers.blockquote = require('./types/blockquote')
 
 /* Stringify `node`. */
 function one (ctx, node, index, parent) {

--- a/packages/rebber/src/types/blockquote.js
+++ b/packages/rebber/src/types/blockquote.js
@@ -1,0 +1,12 @@
+/* Expose. */
+const all = require('../all')
+module.exports = blockquote
+
+/* Stringify a comment `node`. */
+function blockquote (ctx, node) {
+  const source = node.author || 'Anonymous'
+  const innerText = all(ctx, node)
+  return `\\begin{Quotation}{${source}
+${innerText}
+\\end{Quotation}`
+}

--- a/packages/rebber/src/types/blockquote.js
+++ b/packages/rebber/src/types/blockquote.js
@@ -6,7 +6,7 @@ module.exports = blockquote
 function blockquote (ctx, node) {
   const source = node.author || 'Anonymous'
   const innerText = all(ctx, node)
-  return `\\begin{Quotation}{${source}
+  return `\\begin{Quotation}{${source}}
 ${innerText}
 \\end{Quotation}`
 }


### PR DESCRIPTION
This PR adds blockquote support for mdast->latex compilation.

This uses the `Quotation` environment as defined in [this line](https://github.com/zestedesavoir/latex-template/blob/76021abc62562a02628a40a3a52f07fbd80a07a1/zmdocument.cls#L160).

I did not use a "standard" quotation environment as latex has many standard to do that.

Be careful, this will trully work only if #61 is handled. For now I use "anonymous" placeholder for empty source.