### PR TITLE
Fix <<html>> issue.

### DIFF
--- a/packages/remark-fix-guillemets/LICENSE-MIT
+++ b/packages/remark-fix-guillemets/LICENSE-MIT
@@ -1,0 +1,22 @@
+Copyright (c) Zeste de Savoir (https://zestedesavoir.com)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/remark-fix-guillemets/README.md
+++ b/packages/remark-fix-guillemets/README.md
@@ -1,0 +1,76 @@
+# remark-fix-guillemets [![Build Status][build-badge]][build-status] [![Coverage Status][coverage-badge]][coverage-status]
+
+This plugin is used to fix `typographic-plugin` when this plugin is used with `remark-parse`.
+Indeed, when `<<a>>` is parsed by `remark-parse`, the resulting tree is:
+
+```
+root[1] (1:1-1:6, 0-5)
+└─ paragraph[3] (1:1-1:6, 0-5)
+   ├─ text: "<" (1:1-1:2, 0-1)
+   ├─ html: "<a>" (1:2-1:5, 1-4)
+   └─ text: ">" (1:5-1:6, 0-1)
+```
+
+Because remark-textr is used to correct text nodes, here, `<<` is not replaced by `«`.
+
+This plugin replaces the previous tree by:
+```
+root[1] (1:1-1:6, 0-5)
+└─ paragraph[1] (1:1-1:6, 0-5)
+   └─ text: "<<a>>" (1:1-1:6, 0-5)
+```
+
+## Install
+
+[npm][npm]:
+
+```sh
+npm install --save remark-fix-guillemets
+```
+
+
+## Usage
+
+Dependencies:
+
+```javascript
+const unified = require('unified')
+const remarkParse = require('remark-parse')
+const stringify = require('rehype-stringify')
+const remark2rehype = require('remark-rehype')
+
+const remarkFixGuillemets = require('remark-fix-guillemets')
+```
+
+Usage:
+
+```javascript
+unified()
+  .use(remarkParse)
+  .use(remark2rehype)
+  .use(remarkFixGuillemets)
+  .use(stringify)
+```
+
+
+## License
+
+[MIT][license] © [Zeste de Savoir][zds]
+
+<!-- Definitions -->
+
+[build-badge]: https://img.shields.io/travis/zestedesavoir/zmarkdown.svg
+
+[build-status]: https://travis-ci.org/zestedesavoir/zmarkdown
+
+[coverage-badge]: https://img.shields.io/coveralls/zestedesavoir/zmarkdown.svg
+
+[coverage-status]: https://coveralls.io/github/zestedesavoir/zmarkdown
+
+[license]: https://github.com/zestedesavoir/zmarkdown/blob/master/packages/remark-fix-guillemets/LICENSE-MIT
+
+[zds]: https://zestedesavoir.com
+
+[npm]: https://www.npmjs.com/package/remark-fix-guillemets
+
+[textr]: https://github.com/A/textr

--- a/packages/remark-fix-guillemets/README.md
+++ b/packages/remark-fix-guillemets/README.md
@@ -47,8 +47,8 @@ Usage:
 ```javascript
 unified()
   .use(remarkParse)
-  .use(remark2rehype)
   .use(remarkFixGuillemets)
+  .use(remark2rehype)
   .use(stringify)
 ```
 

--- a/packages/remark-fix-guillemets/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-fix-guillemets/__tests__/__snapshots__/index.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`do-not-replace 1`] = `"<p>></p>"`;
+
 exports[`issue-80 1`] = `"<p>«html» «html1» «html2» «html3» «html4» «<strong>bold</strong>»</p>"`;
+
+exports[`no-html-block 1`] = `"<p>« 1 »</p>"`;

--- a/packages/remark-fix-guillemets/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-fix-guillemets/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue-80 1`] = `"<p>«html» «html1» «html2» «html3» «html4» «<strong>bold</strong>»</p>"`;

--- a/packages/remark-fix-guillemets/__tests__/index.js
+++ b/packages/remark-fix-guillemets/__tests__/index.js
@@ -38,3 +38,17 @@ test('issue-80', () => {
   `)
   expect(contents).toMatchSnapshot()
 })
+
+test('no-html-block', () => {
+  const { contents } = render(dedent`
+    << 1 >>
+  `)
+  expect(contents).toMatchSnapshot()
+})
+
+test('do-not-replace', () => {
+  const { contents } = render(dedent`
+    <a>>
+  `)
+  expect(contents).toMatchSnapshot()
+})

--- a/packages/remark-fix-guillemets/__tests__/index.js
+++ b/packages/remark-fix-guillemets/__tests__/index.js
@@ -1,0 +1,40 @@
+import dedent from 'dedent'
+import unified from 'unified'
+import reParse from 'remark-parse'
+import stringify from 'rehype-stringify'
+import remark2rehype from 'remark-rehype'
+
+import remarkFixGuillemets from '../src/'
+import textrGuillemets from 'typographic-guillemets'
+import remarkTextr from '../remark-textr'
+
+
+const render = (text, config) => unified()
+  .use(reParse, {
+    gfm: true,
+    commonmark: false,
+    yaml: false,
+    footnotes: true,
+    /* sets list of known blocks to nothing, otherwise <h3>hey</h3> would become
+    &#x3C;h3>hey&#x3C;/h3> instead of <p>&#x3C;h3>hey&#x3C;/h3></p> */
+    blocks: [],
+  })
+  .use(remarkFixGuillemets)
+  .use(remark2rehype)
+  .use(stringify)
+  .use(remarkTextr,   {
+      plugins: [
+        textrGuillemets,
+      ],
+      options: {
+        locale: 'fr',
+      },
+    })
+  .processSync(text)
+
+test('issue-80', () => {
+  const { contents } = render(dedent`
+    <<html>> <<html1>> <<html2>> <<html3>> <<html4>> <<**bold**>>
+  `)
+  expect(contents).toMatchSnapshot()
+})

--- a/packages/remark-fix-guillemets/__tests__/index.js
+++ b/packages/remark-fix-guillemets/__tests__/index.js
@@ -22,14 +22,14 @@ const render = (text, config) => unified()
   .use(remarkFixGuillemets)
   .use(remark2rehype)
   .use(stringify)
-  .use(remarkTextr,   {
-      plugins: [
-        textrGuillemets,
-      ],
-      options: {
-        locale: 'fr',
-      },
-    })
+  .use(remarkTextr, {
+    plugins: [
+      textrGuillemets,
+    ],
+    options: {
+      locale: 'fr',
+    },
+  })
   .processSync(text)
 
 test('issue-80', () => {

--- a/packages/remark-fix-guillemets/dist/index.js
+++ b/packages/remark-fix-guillemets/dist/index.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var clone = require('clone');
+var visit = require('unist-util-visit');
+
+function plugin() {
+  return transformer;
+}
+
+function transformer(tree) {
+  visit(tree, 'blockquote', visitor);
+}
+
+function visitor(node, index, parent) {
+  if (parent && parent.type === 'figure') return;
+  var lastP = getLast(node.children);
+  if (!lastP || lastP.type !== 'paragraph') return;
+  var lastT = getLast(lastP.children);
+  if (!lastT || lastT.type !== 'text') return;
+
+  var lines = lastT.value.split('\n');
+  var lastLine = getLast(lines);
+  if (!lastLine) return;
+  if (!lastLine.includes(':')) return;
+  var legend = lines.pop().slice(lastLine.indexOf(':') + 1).trim();
+
+  lastT.value = lines.join('\n');
+
+  var figcaption = {
+    type: 'figcaption',
+    children: [{
+      type: 'text',
+      value: legend
+    }],
+    data: {
+      hName: 'figcaption'
+    }
+  };
+
+  var figure = {
+    type: 'figure',
+    children: [clone(node), figcaption],
+    data: {
+      hName: 'figure'
+    }
+  };
+
+  node.type = figure.type;
+  node.children = figure.children;
+  node.data = figure.data;
+}
+
+function getLast(xs) {
+  var len = xs.length;
+  if (!len) return;
+  return xs[len - 1];
+}
+
+module.exports = plugin;

--- a/packages/remark-fix-guillemets/package.json
+++ b/packages/remark-fix-guillemets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-fix-guillemets",
-  "version": "0.0.8",
+  "version": "0.0.1",
   "repository": {
     "url": "https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-fix-guillemets",
     "type": "git"

--- a/packages/remark-fix-guillemets/package.json
+++ b/packages/remark-fix-guillemets/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "remark-fix-guillemets",
+  "version": "0.0.8",
+  "repository": {
+    "url": "https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-fix-guillemets",
+    "type": "git"
+  },
+  "author": "Sébastien (AmarOk) Blin <contact@enconn.fr>",
+  "contributors": [
+    "Sébastien (AmarOk) Blin <contact@enconn.fr>",
+    "François (artragis) Dambrine <perso@francoisdambrine.me>",
+    "Victor Felder <victor@draft.li> (https://draft.li)"
+  ],
+  "scripts": {
+    "pretest": "eslint src",
+    "prepare": "del-cli dist && cross-env BABEL_ENV=production babel --out-dir dist src",
+    "test": "jest",
+    "coverage": "jest --coverage"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "LICENSE-MIT",
+    "dist"
+  ],
+  "engines": {
+    "node": ">=4"
+  },
+  "keywords": [
+    "remark"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "clone": "^2.1.1",
+    "unist-util-visit": "^1.1.3"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.24.1",
+    "babel-jest": "^20.0.3",
+    "babel-preset-es2015": "^6.24.1",
+    "cross-env": "^5.0.1",
+    "dedent": "^0.7.0",
+    "del-cli": "^1.0.0",
+    "eslint": "^4.0.0",
+    "jest": "^20.0.4",
+    "rehype-stringify": "^3.0.0",
+    "remark-parse": "^3.0.1",
+    "remark-rehype": "^2.0.1",
+    "textr": "^0.3.0",
+    "typographic-guillemets": "^0.0.6",
+    "unified": "^6.1.5"
+  }
+}

--- a/packages/remark-fix-guillemets/remark-textr.js
+++ b/packages/remark-fix-guillemets/remark-textr.js
@@ -1,0 +1,21 @@
+const visit = require('unist-util-visit')
+const textr = require('textr')
+
+module.exports = plugin
+
+function plugin ({ plugins = [], options = {} } = {}) {
+  let fn
+  return transformer
+
+  function transformer (tree) {
+    fn = plugins.reduce(
+      (processor, p) => processor.use(typeof p === 'string' ? require(p) : p),
+      textr(options)
+    )
+
+    visit(tree, 'text', visitor)
+  }
+  function visitor (node) {
+    node.value = fn(node.value)
+  }
+}

--- a/packages/remark-fix-guillemets/src/index.js
+++ b/packages/remark-fix-guillemets/src/index.js
@@ -1,0 +1,31 @@
+const visit = require('unist-util-visit')
+
+function plugin () {
+  return transformer
+}
+
+function transformer (tree) {
+  visit(tree, 'paragraph', visitor)
+}
+
+function visitor (node, index, parent) {
+  for (let c = 1; c < node.children.length - 1; c++) {
+    const child = node.children[c]
+    if (child.type === 'html') {
+      const previousNode = node.children[c - 1]
+      const nextNode = node.children[c + 1]
+
+      if (previousNode.type === 'text' &&
+        previousNode.value.slice(-1) === '<' &&
+        nextNode.type === 'text' &&
+        nextNode.value[0] === '>') {
+        previousNode.value += child.value
+        previousNode.value += nextNode.value
+        node.children.splice(c, 2)
+        c -= 1
+      }
+    }
+  }
+}
+
+module.exports = plugin


### PR DESCRIPTION
cf #80 

Now:
```
<<html>> <<html1>> <<html2>> <<html3>> <<html4>> <<**bold**>>
```

gives:
```
<p>«html» «html1» «html2» «html3» «html4» «<strong>bold</strong>»</p>
```