### PR TITLE
zmarkdown: don't ensure pinged usernames exist

### DIFF
--- a/packages/remark-ping/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-ping/__tests__/__snapshots__/index.js.snap
@@ -232,6 +232,7 @@ Object {
             "hProperties": Object {
               "class": "ping",
               "href": "/membres/voir/I AM CLEM/",
+              "rel": "nofollow",
             },
           },
           "position": Position {
@@ -333,6 +334,7 @@ Object {
             "hProperties": Object {
               "class": "ping",
               "href": "/membres/voir/I AM CLEM/",
+              "rel": "nofollow",
             },
           },
           "position": Position {
@@ -404,6 +406,7 @@ Object {
                     "hProperties": Object {
                       "class": "ping",
                       "href": "/membres/voir/I AM CLEM/",
+                      "rel": "nofollow",
                     },
                   },
                   "position": Position {
@@ -486,6 +489,7 @@ Object {
                 "hProperties": Object {
                   "class": "ping",
                   "href": "/membres/voir/I AM CLEM/",
+                  "rel": "nofollow",
                 },
               },
               "position": Position {
@@ -571,6 +575,7 @@ Object {
             "hProperties": Object {
               "class": "ping",
               "href": "/membres/voir/I AM CLEM/",
+              "rel": "nofollow",
             },
           },
           "position": Position {
@@ -639,6 +644,7 @@ Object {
                 "hProperties": Object {
                   "class": "ping",
                   "href": "/membres/voir/I AM CLEM/",
+                  "rel": "nofollow",
                 },
               },
               "position": Position {
@@ -723,6 +729,7 @@ Object {
                 "hProperties": Object {
                   "class": "ping",
                   "href": "/membres/voir/I AM CLEM/",
+                  "rel": "nofollow",
                 },
               },
               "position": Position {

--- a/packages/remark-ping/__tests__/index.js
+++ b/packages/remark-ping/__tests__/index.js
@@ -73,20 +73,40 @@ const outputs = [
     <p>ping @Clem</p>
     <p>ping @<strong>FOO BAR</strong></p>
     <p>no ping @dqsjdjsqjhdshqjkhfyhefezhjzjhdsjlfjlsqjdfjhsd</p>
-    <p>no ping <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></p>
+    <p>no ping <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a></p>
   `,
   dedent`
-    <h2>Test ping <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></h2>
+    <h2>\
+    Test ping \
+    <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a>\
+    </h2>
     <blockquote>
     <blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></p>
+    <p>\
+    no metadata output \
+    <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">\
+    I AM CLEM\
+    </a>\
+    </p>
     </blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></p>
+    <p>\
+    no metadata output \
+    <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a>\
+    </p>
     </blockquote>
-    <p>ping <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></p>
-    <p>ping <em><a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></em></p>
+    <p>\
+    ping \
+    <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a>\
+    </p>
+    <p>\
+    ping \
+    <em><a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a></em>\
+    </p>
     <blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" class="ping">I AM CLEM</a></p>
+    <p>\
+    no metadata output \
+    <a href="/membres/voir/I AM CLEM/" class="ping" rel="nofollow">I AM CLEM</a>\
+    </p>
     </blockquote>
   `,
 ]

--- a/packages/remark-ping/src/index.js
+++ b/packages/remark-ping/src/index.js
@@ -34,7 +34,8 @@ module.exports = function plugin ({
           hName: 'a',
           hProperties: {
             href: url,
-            class: 'ping'
+            class: 'ping',
+            rel: 'nofollow'
           }
         }
       })

--- a/packages/zmarkdown/package.json
+++ b/packages/zmarkdown/package.json
@@ -42,7 +42,6 @@
     "remark-ping": "^1.0.8",
     "remark-rehype": "^2.0.1",
     "remark-sub-super": "^1.0.7",
-    "sync-request": "^4.1.0",
     "textr": "^0.3.0",
     "to-vfile": "^2.1.2",
     "typographic-apostrophes": "^1.1.1",

--- a/packages/zmarkdown/remark-config.js
+++ b/packages/zmarkdown/remark-config.js
@@ -1,4 +1,3 @@
-const request = require('sync-request')
 const textrApostrophes = require('typographic-apostrophes')
 const textrApostrophesForPlurals = require('typographic-apostrophes-for-possessive-plurals')
 const textrCopyright = require('typographic-copyright')
@@ -266,19 +265,7 @@ const remarkConfig = {
   },
 
   ping: {
-    pingUsername: (username) => {
-      try {
-        const result = request(
-          'GET',
-          `https://zestedesavoir.com/api/membres/exists/?search=${username}`,
-          {timeout: 300}
-        )
-        return result.statusCode === 200
-      } catch (ex) {
-        console.error(ex)
-        return false
-      }
-    },
+    pingUsername: (_username) => true,
     userURL: (username) => `/membres/voir/${username}/`,
   },
 


### PR DESCRIPTION
Requested in https://github.com/zestedesavoir/zds-site/pull/4617 (fr).

Any `@mention` will be considered valid and will be transformed to an
HTML link. That link will point to a non-existent web page (showing a
404 error) if the mentioned username doesn't exist, but it's not a big
deal.