### PR TITLE
fix/inline-code: Fix issue with inlineCode

### DIFF
--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -252,11 +252,11 @@ inlinecode}
 
 
 
-\\\\CodeInline{a code with \\\\}
+\\\\CodeInline{a code with \\\\textbackslash{}}
 
 
 
-\\\\CodeInline{a \\\\text in \\\\LaTeX \\\\\\\\}
+\\\\CodeInline{a \\\\textbackslash{}text in \\\\textbackslash{}LaTeX \\\\textbackslash{}\\\\textbackslash{}}
 
 "
 `;
@@ -379,7 +379,7 @@ bar}
 
 
 \\\\begin{Quotation}
-\\\\CodeInline{fo\\\\o
+\\\\CodeInline{fo\\\\textbackslash{}o
 bar}
 \\\\end{Quotation}
 

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -201,67 +201,67 @@ Nor should these, which occur in code spans:
 
 
 
-Backslash: \\\\CodeInline{\\\\\\\\}
+Backslash: \\\\CodeInline{\\\\textbackslash{}\\\\textbackslash{}}
 
 
 
-Backtick: \\\\CodeInline{\\\\\`}
+Backtick: \\\\CodeInline{\\\\textbackslash{}\`}
 
 
 
-Asterisk: \\\\CodeInline{\\\\*}
+Asterisk: \\\\CodeInline{\\\\textbackslash{}*}
 
 
 
-Underscore: \\\\CodeInline{\\\\_}
+Underscore: \\\\CodeInline{\\\\textbackslash{}\\\\_}
 
 
 
-Left brace: \\\\CodeInline{\\\\\\\\{}
+Left brace: \\\\CodeInline{\\\\textbackslash{}\\\\{}
 
 
 
-Right brace: \\\\CodeInline{\\\\\\\\}}
+Right brace: \\\\CodeInline{\\\\textbackslash{}\\\\}}
 
 
 
-Left bracket: \\\\CodeInline{\\\\[}
+Left bracket: \\\\CodeInline{\\\\textbackslash{}[}
 
 
 
-Right bracket: \\\\CodeInline{\\\\]}
+Right bracket: \\\\CodeInline{\\\\textbackslash{}]}
 
 
 
-Left paren: \\\\CodeInline{\\\\(}
+Left paren: \\\\CodeInline{\\\\textbackslash{}(}
 
 
 
-Right paren: \\\\CodeInline{\\\\)}
+Right paren: \\\\CodeInline{\\\\textbackslash{})}
 
 
 
-Greater-than: \\\\CodeInline{\\\\>}
+Greater-than: \\\\CodeInline{\\\\textbackslash{}>}
 
 
 
-Hash: \\\\CodeInline{\\\\#}
+Hash: \\\\CodeInline{\\\\textbackslash{}\\\\#}
 
 
 
-Period: \\\\CodeInline{\\\\.}
+Period: \\\\CodeInline{\\\\textbackslash{}.}
 
 
 
-Bang: \\\\CodeInline{\\\\!}
+Bang: \\\\CodeInline{\\\\textbackslash{}!}
 
 
 
-Plus: \\\\CodeInline{\\\\+}
+Plus: \\\\CodeInline{\\\\textbackslash{}+}
 
 
 
-Minus: \\\\CodeInline{\\\\-}"
+Minus: \\\\CodeInline{\\\\textbackslash{}-}"
 `;
 
 exports[`#basic properly renders blockquotes-with-code-blocks.txt 1`] = `
@@ -2325,7 +2325,7 @@ else:
 
 exports[`#misc properly renders backtick-escape.txt 1`] = `
 "\`This also should not be in code.\`
-\\\\textbackslash{}\\\\CodeInline{This should be in code.\\\\\\\\}
+\\\\textbackslash{}\\\\CodeInline{This should be in code.\\\\textbackslash{}\\\\textbackslash{}}
 \`And finally this should not be in code.\`"
 `;
 

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -30,7 +30,8 @@ const rebberConfig = {
     warningCustomBlock: require('rebber-plugins/dist/type/customBlocks'),
 
     inlineCode: (ctx, node) => {
-      const escaped = node.value.replace('{', '\\{').replace('}', '\\}')
+      const escape = require('rebber/dist/escaper')
+      const escaped = escape(node.value)
       return `\\CodeInline{${escaped}}`
     }
   },

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -1,4 +1,5 @@
 const remarkConfig = require('./remark')
+const escape = require('rebber/dist/escaper')
 
 const rebberConfig = {
   preprocessors: {
@@ -30,7 +31,6 @@ const rebberConfig = {
     warningCustomBlock: require('rebber-plugins/dist/type/customBlocks'),
 
     inlineCode: (ctx, node) => {
-      const escape = require('rebber/dist/escaper')
       const escaped = escape(node.value)
       return `\\CodeInline{${escaped}}`
     }


### PR DESCRIPTION
inlineCode cause trouble with special char (due to mintinline).
inlineCode use now texttt instead of mintinline and special char
need to be escaped.

Related in [this template PR](https://github.com/zestedesavoir/latex-template/pull/80)