### PR TITLE
Add titled custom block

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -173,6 +173,15 @@ question \\\\texttt{coded}
 \\\\textbf{error}
 foo bar \\\\\\\\
 baz
+\\\\end{Error}
+
+
+\\\\begin{Error}
+a bad error
+
+\\\\textbf{error}
+foo bar \\\\\\\\
+baz
 \\\\end{Error}"
 `;
 

--- a/packages/rebber-plugins/__tests__/fixtures/blocks.fixture.md
+++ b/packages/rebber-plugins/__tests__/fixtures/blocks.fixture.md
@@ -14,3 +14,8 @@
 | **error**
 | foo bar··
 | baz
+
+[[e | a bad error]]
+| **error**
+| foo bar··
+| baz

--- a/packages/rebber-plugins/__tests__/rebber.test.js
+++ b/packages/rebber-plugins/__tests__/rebber.test.js
@@ -421,7 +421,7 @@ test('custom-blocks', () => {
       a: 'warning ico-after',
       erreur: 'error ico-after',
       e: 'error ico-after',
-    })
+    }, true)
     .use(rebber, integrationConfig)
     .processSync(fixture.replace(/·/g, ' '))
 

--- a/packages/rebber-plugins/dist/type/customBlocks.js
+++ b/packages/rebber-plugins/dist/type/customBlocks.js
@@ -14,6 +14,11 @@ var defaultMacros = {
 
 function customBlock(ctx, node) {
   var blockMacro = ctx[node.type] || defaultMacros[node.type] || defaultMacros.defaultBlock;
+  node.children.forEach(function (child) {
+    if (child.type.startsWith('heading') || child.type.startsWith('body')) {
+      child.type = 'paragraph';
+    }
+  });
   var innerText = all(ctx, node).trim();
   var options = ctx.customBlocks || {};
 

--- a/packages/rebber-plugins/src/type/customBlocks.js
+++ b/packages/rebber-plugins/src/type/customBlocks.js
@@ -12,6 +12,11 @@ const defaultMacros = {
 
 function customBlock (ctx, node) {
   const blockMacro = ctx[node.type] || defaultMacros[node.type] || defaultMacros.defaultBlock
+  node.children.forEach(child => {
+    if (child.type.startsWith('heading') || child.type.startsWith('body')) {
+      child.type = 'paragraph'
+    }
+  })
   const innerText = all(ctx, node).trim()
   const options = ctx.customBlocks || {}
 

--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -64,7 +64,7 @@ unified()
   .use(remarkCustomBlocks, {
     someType: 'a-css-class another-class',
     anotherType: 'foo',
-  })
+  }, true)
   .use(remark2rehype)
   .use(stringify)
 ```
@@ -80,6 +80,8 @@ The sample configuration provided above would have the following effect:
     | content
     [[anotherType]]
     | content
+    [[anotherType | title ]]
+    | content
     ```
 
 1. This Remark plugin would create [mdast][mdast] nodes for these two blocks, these nodes would be of type:
@@ -91,6 +93,7 @@ The sample configuration provided above would have the following effect:
 
     * `<div class="a-css-class another-class">…`
     * `<div class="foo">…`
+    * `<div class="foo"><p>title</p>…`
 
 ## License
 

--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -93,7 +93,7 @@ The sample configuration provided above would have the following effect:
 
     * `<div class="a-css-class another-class">…`
     * `<div class="foo">…`
-    * `<div class="foo"><p>title</p>…`
+    * `<div class="foo"><div class="heading">title</div>…`
 
 ## License
 

--- a/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
@@ -26,7 +26,38 @@ exports[`blocks 1`] = `
 <div class=\\"spoiler\\"><p>Multiline block</p><blockquote>
 <p>with blockquote !</p>
 </blockquote></div>
-<p>| Not a block</p>"
+<p>| Not a block</p>
+<p>[[attention | title]]\n| only parsed if allowTitles is true</p>"
+`;
+
+exports[`blocks with allowTitle 1`] = `
+"<div class=\\"spoiler\\"><p>Secret Block</p></div>
+<div class=\\"spoiler\\"><p>Secret Block</p></div>
+<div class=\\"spoiler\\"><p>another</p></div>
+<blockquote>
+<div class=\\"spoiler\\"><blockquote>
+<p>Blockquote in secret block in blockquote</p>
+</blockquote></div>
+</blockquote>
+<div class=\\"information ico-after\\"><p>Information Block</p></div>
+<div class=\\"information ico-after\\"><p>an other</p></div>
+<div class=\\"question ico-after\\"><p>Question Block</p></div>
+<div class=\\"question ico-after\\"><p>an other</p></div>
+<div class=\\"warning ico-after\\"><p>Attention Block</p></div>
+<div class=\\"warning ico-after\\"><p>an other</p></div>
+<div class=\\"error ico-after\\"><p>Erreur Block</p></div>
+<div class=\\"error ico-after\\"><p>an other</p></div>
+<p>[[se]]
+| not a block</p>
+<p>[[secretsecret]]
+| not a block</p>
+<p>[[SECRET]]
+| not a block</p>
+<div class=\\"spoiler\\"><p>Multiline block</p><blockquote>
+<p>with blockquote !</p>
+</blockquote></div>
+<p>| Not a block</p>
+<div class=\\"warning ico-after\\"><p>title</p><p>only parsed if allowTitles is true</p></div>"
 `;
 
 exports[`regression 1 1`] = `

--- a/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
@@ -1,67 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`blocks 1`] = `
-"<div class=\\"spoiler\\"><p>Secret Block</p></div>
-<div class=\\"spoiler\\"><p>Secret Block</p></div>
-<div class=\\"spoiler\\"><p>another</p></div>
+"<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Secret Block</p></div></div>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Secret Block</p></div></div>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>another</p></div></div>
 <blockquote>
-<div class=\\"spoiler\\"><blockquote>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><blockquote>
 <p>Blockquote in secret block in blockquote</p>
-</blockquote></div>
+</blockquote></div></div>
 </blockquote>
-<div class=\\"information ico-after\\"><p>Information Block</p></div>
-<div class=\\"information ico-after\\"><p>an other</p></div>
-<div class=\\"question ico-after\\"><p>Question Block</p></div>
-<div class=\\"question ico-after\\"><p>an other</p></div>
-<div class=\\"warning ico-after\\"><p>Attention Block</p></div>
-<div class=\\"warning ico-after\\"><p>an other</p></div>
-<div class=\\"error ico-after\\"><p>Erreur Block</p></div>
-<div class=\\"error ico-after\\"><p>an other</p></div>
+<div class=\\"custom-block information,ico-after\\"><div class=\\"custom-block-body\\"><p>Information Block</p></div></div>
+<div class=\\"custom-block information,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block question,ico-after\\"><div class=\\"custom-block-body\\"><p>Question Block</p></div></div>
+<div class=\\"custom-block question,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-body\\"><p>Attention Block</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block error,ico-after\\"><div class=\\"custom-block-body\\"><p>Erreur Block</p></div></div>
+<div class=\\"custom-block error,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
 <p>[[se]]
 | not a block</p>
 <p>[[secretsecret]]
 | not a block</p>
 <p>[[SECRET]]
 | not a block</p>
-<div class=\\"spoiler\\"><p>Multiline block</p><blockquote>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Multiline block</p><blockquote>
 <p>with blockquote !</p>
-</blockquote></div>
+</blockquote></div></div>
 <p>| Not a block</p>
-<p>[[attention | title]]\n| only parsed if allowTitles is true</p>"
+<p>[[attention | title]]
+| only parsed if allowTitles is true</p>
+<p>[[attention |title]]
+| only parsed if allowTitles is true</p>
+<p>[[attention| title]]
+| only parsed if allowTitles is true</p>
+<p>[[attention|title]]
+| only parsed if allowTitles is true</p>
+<p>[[attention||title]]
+| not parsed at all</p>
+<p>[[attention|title with many words I'm happy]]
+| only parsed if allowTitles is true</p>"
 `;
 
 exports[`blocks with allowTitle 1`] = `
-"<div class=\\"spoiler\\"><p>Secret Block</p></div>
-<div class=\\"spoiler\\"><p>Secret Block</p></div>
-<div class=\\"spoiler\\"><p>another</p></div>
+"<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Secret Block</p></div></div>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Secret Block</p></div></div>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>another</p></div></div>
 <blockquote>
-<div class=\\"spoiler\\"><blockquote>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><blockquote>
 <p>Blockquote in secret block in blockquote</p>
-</blockquote></div>
+</blockquote></div></div>
 </blockquote>
-<div class=\\"information ico-after\\"><p>Information Block</p></div>
-<div class=\\"information ico-after\\"><p>an other</p></div>
-<div class=\\"question ico-after\\"><p>Question Block</p></div>
-<div class=\\"question ico-after\\"><p>an other</p></div>
-<div class=\\"warning ico-after\\"><p>Attention Block</p></div>
-<div class=\\"warning ico-after\\"><p>an other</p></div>
-<div class=\\"error ico-after\\"><p>Erreur Block</p></div>
-<div class=\\"error ico-after\\"><p>an other</p></div>
+<div class=\\"custom-block information,ico-after\\"><div class=\\"custom-block-body\\"><p>Information Block</p></div></div>
+<div class=\\"custom-block information,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block question,ico-after\\"><div class=\\"custom-block-body\\"><p>Question Block</p></div></div>
+<div class=\\"custom-block question,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-body\\"><p>Attention Block</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
+<div class=\\"custom-block error,ico-after\\"><div class=\\"custom-block-body\\"><p>Erreur Block</p></div></div>
+<div class=\\"custom-block error,ico-after\\"><div class=\\"custom-block-body\\"><p>an other</p></div></div>
 <p>[[se]]
 | not a block</p>
 <p>[[secretsecret]]
 | not a block</p>
 <p>[[SECRET]]
 | not a block</p>
-<div class=\\"spoiler\\"><p>Multiline block</p><blockquote>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Multiline block</p><blockquote>
 <p>with blockquote !</p>
-</blockquote></div>
+</blockquote></div></div>
 <p>| Not a block</p>
-<div class=\\"warning ico-after\\"><p>title</p><p>only parsed if allowTitles is true</p></div>"
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-heading\\">title</div><div class=\\"custom-block-body\\"><p>only parsed if allowTitles is true</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-heading\\">title</div><div class=\\"custom-block-body\\"><p>only parsed if allowTitles is true</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-heading\\">title</div><div class=\\"custom-block-body\\"><p>only parsed if allowTitles is true</p></div></div>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-heading\\">title</div><div class=\\"custom-block-body\\"><p>only parsed if allowTitles is true</p></div></div>
+<p>[[attention||title]]
+| not parsed at all</p>
+<div class=\\"custom-block warning,ico-after\\"><div class=\\"custom-block-heading\\">title with many words I'm happy</div><div class=\\"custom-block-body\\"><p>only parsed if allowTitles is true</p></div></div>"
 `;
 
 exports[`regression 1 1`] = `
 "<p>content before</p>
-<div class=\\"spoiler\\"><p>Block</p></div>
+<div class=\\"custom-block spoiler\\"><div class=\\"custom-block-body\\"><p>Block</p></div></div>
 <p>with content after</p>"
 `;

--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -6,7 +6,7 @@ import remark2rehype from 'remark-rehype'
 
 import plugin from '../src/'
 
-const render = (text, activateTitle) => unified()
+const render = (text, allowTitle) => unified()
   .use(reParse)
   .use(remark2rehype)
   .use(plugin, {
@@ -20,15 +20,15 @@ const render = (text, activateTitle) => unified()
     a: 'warning ico-after',
     erreur: 'error ico-after',
     e: 'error ico-after',
-  }, activateTitle)
+  }, allowTitle)
   .use(stringify)
   .processSync(text)
 
 const nameMap = {
-  false: 'blocks',
-  true: 'blocks with allowTitle'
+  'blocks': false,
+  'blocks with allowTitle': true,
 }
-Object.keys(nameMap).forEach(t => test(nameMap[t], () => {
+Object.keys(nameMap).forEach(t => test(t, () => {
   const {contents} = render(dedent`
     [[s]]
     | Secret Block
@@ -85,7 +85,22 @@ Object.keys(nameMap).forEach(t => test(nameMap[t], () => {
     
     [[attention | title]]
     | only parsed if allowTitles is true
-  `, t === 'true')
+    
+    [[attention |title]]
+    | only parsed if allowTitles is true
+    
+    [[attention| title]]
+    | only parsed if allowTitles is true
+    
+    [[attention|title]]
+    | only parsed if allowTitles is true
+    
+    [[attention||title]]
+    | not parsed at all
+    
+    [[attention|title with many words I'm happy]]
+    | only parsed if allowTitles is true
+  `, nameMap[t])
   expect(contents).toMatchSnapshot()
 }))
 

--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -6,7 +6,7 @@ import remark2rehype from 'remark-rehype'
 
 import plugin from '../src/'
 
-const render = text => unified()
+const render = (text, activateTitle) => unified()
   .use(reParse)
   .use(remark2rehype)
   .use(plugin, {
@@ -20,67 +20,74 @@ const render = text => unified()
     a: 'warning ico-after',
     erreur: 'error ico-after',
     e: 'error ico-after',
-  })
+  }, activateTitle)
   .use(stringify)
   .processSync(text)
 
-test('blocks', () => {
+const nameMap = {
+  false: 'blocks',
+  true: 'blocks with allowTitle'
+}
+Object.keys(nameMap).forEach(t => test(nameMap[t], () => {
   const {contents} = render(dedent`
     [[s]]
     | Secret Block
-
+    
     [[s]]
     |Secret Block
-
+    
     [[secret]]
     | another
-
+    
     > [[s]]
     > | > Blockquote in secret block in blockquote
-
+    
     [[i]]
     | Information Block
-
+    
     [[information]]
     | an other
-
+    
     [[q]]
     | Question Block
-
+    
     [[question]]
     | an other
-
+    
     [[a]]
     | Attention Block
-
+    
     [[attention]]
     | an other
-
+    
     [[e]]
     | Erreur Block
-
+    
     [[erreur]]
     | an other
-
-
+    
+    
     [[se]]
     | not a block
-
+    
     [[secretsecret]]
     | not a block
-
+    
     [[SECRET]]
     | not a block
-
+    
     [[s]]
     | Multiline block
     |
     | > with blockquote !
-
+    
     | Not a block
-  `)
+    
+    [[attention | title]]
+    | only parsed if allowTitles is true
+  `, t === 'true')
   expect(contents).toMatchSnapshot()
-})
+}))
 
 test('regression 1', () => {
   const {contents} = render(dedent`

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -115,13 +115,13 @@ secret
 
 
 \\\\begin{Question}
-question \\\\CodeInline{coded}
+question \\\\textbackslash{}CodeInline\\\\{coded\\\\}
 \\\\end{Question}
 
 
 \\\\begin{Error}
-\\\\textbf{error}
-foo bar \\\\\\\\
+\\\\textbackslash{}textbf\\\\{error\\\\}
+foo bar \\\\textbackslash{}\\\\textbackslash{}
 baz
 \\\\end{Error}"
 `;

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -3983,9 +3983,9 @@ another
 
 \\\\begin{Quotation}
 \\\\begin{Spoiler}
-\\\\begin{Quotation}
+\\\\textbackslash{}begin\\\\{Quotation\\\\}
 Blockquote in secret block in blockquote
-\\\\end{Quotation}
+\\\\textbackslash{}end\\\\{Quotation\\\\}
 \\\\end{Spoiler}
 \\\\end{Quotation}
 
@@ -4049,9 +4049,9 @@ an other
 \\\\begin{Spoiler}
 Multiline block
 
-\\\\begin{Quotation}
+\\\\textbackslash{}begin\\\\{Quotation\\\\}
 with blockquote !
-\\\\end{Quotation}
+\\\\textbackslash{}end\\\\{Quotation\\\\}
 \\\\end{Spoiler}
 
 

--- a/packages/zmarkdown/__tests__/fixtures/zds/extensions/customblock.html
+++ b/packages/zmarkdown/__tests__/fixtures/zds/extensions/customblock.html
@@ -1,29 +1,29 @@
-<div class="spoiler"><p>Secret Block</p></div>
-<div class="spoiler"><p>Secret Block</p></div>
-<div class="spoiler"><p>another</p></div>
+<div class="custom-block spoiler"><div class="custom-block-body"><p>Secret Block</p></div></div>
+<div class="custom-block spoiler"><div class="custom-block-body"><p>Secret Block</p></div></div>
+<div class="custom-block spoiler"><div class="custom-block-body"><p>another</p></div></div>
 <blockquote>
-<div class="spoiler"><blockquote>
+<div class="custom-block spoiler"><div class="custom-block-body"><blockquote>
 <p>Blockquote in secret block in blockquote</p>
-</blockquote></div>
+</blockquote></div></div>
 </blockquote>
-<div class="information ico-after"><p>Information Block</p></div>
-<div class="information ico-after"><p>an other</p></div>
-<div class="question ico-after"><p>Question Block</p></div>
-<div class="question ico-after"><p>an other</p></div>
-<div class="warning ico-after"><p>Attention Block</p></div>
-<div class="warning ico-after"><p>an other</p></div>
-<div class="error ico-after"><p>Erreur Block</p></div>
-<div class="error ico-after"><p>an other</p></div>
+<div class="custom-block information ico-after"><div class="custom-block-body"><p>Information Block</p></div></div>
+<div class="custom-block information ico-after"><div class="custom-block-body"><p>an other</p></div></div>
+<div class="custom-block question ico-after"><div class="custom-block-body"><p>Question Block</p></div></div>
+<div class="custom-block question ico-after"><div class="custom-block-body"><p>an other</p></div></div>
+<div class="custom-block warning ico-after"><div class="custom-block-body"><p>Attention Block</p></div></div>
+<div class="custom-block warning ico-after"><div class="custom-block-body"><p>an other</p></div></div>
+<div class="custom-block error ico-after"><div class="custom-block-body"><p>Erreur Block</p></div></div>
+<div class="custom-block error ico-after"><div class="custom-block-body"><p>an other</p></div></div>
 <p>[[se]]
 | not a block</p>
 <p>[[secretsecret]]
 | not a block</p>
 <p>[[SECRET]]
 | not a block</p>
-<div class="spoiler"><p>Multiline block</p><blockquote>
+<div class="custom-block spoiler"><div class="custom-block-body"><p>Multiline block</p><blockquote>
 <p>with blockquote !</p>
-</blockquote></div>
+</blockquote></div></div>
 <p>| Not a block</p>
 <p>content before</p>
-<div class="spoiler"><p>A Block</p></div>
+<div class="custom-block spoiler"><div class="custom-block-body"><p>A Block</p></div></div>
 <p>with content after</p>

--- a/packages/zmarkdown/config/remark.js
+++ b/packages/zmarkdown/config/remark.js
@@ -86,6 +86,7 @@ const remarkConfig = {
     a: 'warning ico-after',
     erreur: 'error ico-after',
     e: 'error ico-after',
+    neutre: 'neutral',
   },
 
   escapeEscaped: ['&'],

--- a/packages/zmarkdown/index.js
+++ b/packages/zmarkdown/index.js
@@ -83,7 +83,7 @@ const zmdParser = (config, target) => {
     .use(remarkAlign, config.alignBlocks)
     .use(remarkCaptions, config.captions)
     .use(remarkComments)
-    .use(remarkCustomBlocks, config.customBlocks)
+    .use(remarkCustomBlocks, config.customBlocks, true)
     .use(remarkDisableTokenizers, config.disableTokenizers)
     .use(remarkEmoticons, config.emoticons)
     .use(remarkEscapeEscaped, config.escapeEscaped)


### PR DESCRIPTION
This integrates two functionality in the way zmd uses custom-block:

- neutral block (new type of block)
- titled block (extends the syntax)

I make the syntax extension compatible with the old syntax so that without changing anything we can upgrade the remark-custom-block dependency.

For now, I just push the titles into a bare `paragraph` node. I don't know if this is what we expect or if it needs to be enhanced.

The former issue #184 just gives information about the synthax, not, the rendering. Two solutions have been discussed : 

- use a "title" node or something equivalent
- give the node a css class.

What do we trully want? Whant do we want to be customized?