### PR TITLE
Adding missing definitions to the README of remark-grid-tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
   transformation of MDAST into `latex` code. This code must be included inside a custom latex to be compiled.
   Have a look at `https://github.com/zestedesavoir/latex-template/blob/master/zmdocument.cls` to get a working example.
 
-* [**rehype-abbr**][rehype-abbr]
-
-  This plugin parses custom Markdown syntax to produce HTML abbreviations. This plugin is deprecated. See `remark-abbr`
-
 * [**remark-abbr**][remark-abbr]
 
   This plugin parses `*[ABBR]: abbr definition` and then replace all ABBR instance in text with a new MDAST node so that `rehype` can parse it into `abbr` html tag.
@@ -143,7 +139,6 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
 
 [rebber]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/rebber#rebber--
 [rebber-plugins]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/rebber-plugins#rebber-plugins--
-[rehype-abbr]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/rehype-abbr#rehype-abbr--
 [remark-abbr]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-abbr#remark-abbr--
 [rehype-footnotes-title]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/rehype-footnotes-title#rehype-footnotes-title--
 [rehype-html-blocks]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/rehype-html-blocks#rehype-html-blocks--

--- a/packages/remark-grid-tables/README.md
+++ b/packages/remark-grid-tables/README.md
@@ -147,3 +147,9 @@ unified()
 [zds]: https://zestedesavoir.com
 
 [npm]: https://www.npmjs.com/package/remark-grid-tables
+
+[remark]: https://github.com/wooorm/remark
+
+[mdast]: https://github.com/wooorm/mdast
+
+[rehype]: https://github.com/wooorm/rehype


### PR DESCRIPTION
Hi !

A quick fix to the README of remark-grid-tables.