### PR TITLE
Add compiler to remark-align

### DIFF
--- a/packages/remark-align/.eslintrc.json
+++ b/packages/remark-align/.eslintrc.json
@@ -26,7 +26,7 @@
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
     "camelcase": [2, {"properties": "never"}],
-    "comma-dangle": [1, "always-multiline"],
+    "comma-dangle": [2, "always-multiline"],
     "comma-spacing": [2, {"before": false, "after": true}],
     "comma-style": [2, "last"],
     "computed-property-spacing": [2, "never"],

--- a/packages/remark-align/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-align/__tests__/__snapshots__/index.js.snap
@@ -102,6 +102,26 @@ exports[`list-block 1`] = `
 </ul></div>"
 `;
 
+exports[`render md 1`] = `
+"# title
+
+<-
+ foo 
+<-
+
+# title
+
+->
+ **foo** 
+<-
+
+->
+  
+![img](src)
+->
+"
+`;
+
 exports[`right-no-end 1`] = `
 "<h1>title</h1>
 <p>-> foo</p>

--- a/packages/remark-align/__tests__/index.js
+++ b/packages/remark-align/__tests__/index.js
@@ -3,6 +3,7 @@ import unified from 'unified'
 import reParse from 'remark-parse'
 import stringify from 'rehype-stringify'
 import remark2rehype from 'remark-rehype'
+const remarkStringify = require('remark-stringify')
 
 import remarkAlign from '../src/'
 
@@ -12,6 +13,13 @@ const render = (text, config) => unified()
   .use(remark2rehype)
   .use(stringify)
   .processSync(text)
+
+const renderToMarkdown = (initialMarkdwon, config) => unified()
+  .use(reParse)
+  .use(remarkStringify)
+  .use(remarkAlign, config)
+  .processSync(initialMarkdwon)
+
 
 const alignFixture = dedent`
   Test align
@@ -163,6 +171,23 @@ test('left align', () => {
     <- foo <-
 
     # title
+  `)
+  expect(contents).toMatchSnapshot()
+})
+
+test('render md', () => {
+  const {contents} = renderToMarkdown(dedent`
+    # title
+
+    <- foo <-
+
+    # title
+    
+    -> **foo** <-
+    
+    ->  
+    ![img](src)
+    ->
   `)
   expect(contents).toMatchSnapshot()
 })

--- a/packages/remark-align/dist/index.js
+++ b/packages/remark-align/dist/index.js
@@ -104,4 +104,31 @@ module.exports = function plugin() {
   var blockMethods = Parser.prototype.blockMethods;
   blockTokenizers.align_blocks = alignTokenizer;
   blockMethods.splice(blockMethods.indexOf('fencedCode') + 1, 0, 'align_blocks');
+
+  var Compiler = this.Compiler;
+
+  // Stringify
+  if (Compiler) {
+    var visitors = Compiler.prototype.visitors;
+    var alignCompiler = function alignCompiler(node) {
+      var startMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '->'
+      };
+      var endMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '<-'
+      };
+      var innerString = this.all(node).join('');
+      var nodeAlignType = node.type.replace(/Aligned/, '');
+      var startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : '';
+      var endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : '';
+      return startMarker + '\n' + innerString + '\n' + endMarker;
+    };
+    visitors.leftAligned = alignCompiler;
+    visitors.rightAligned = alignCompiler;
+    visitors.centerAligned = alignCompiler;
+  }
 };

--- a/packages/remark-align/package.json
+++ b/packages/remark-align/package.json
@@ -46,6 +46,7 @@
     "rehype-stringify": "^3.0.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
+    "remark-stringify": "^5.0.0",
     "unified": "^6.1.5"
   }
 }

--- a/packages/remark-align/src/index.js
+++ b/packages/remark-align/src/index.js
@@ -105,4 +105,31 @@ module.exports = function plugin (classNames = {}) {
   const blockMethods = Parser.prototype.blockMethods
   blockTokenizers.align_blocks = alignTokenizer
   blockMethods.splice(blockMethods.indexOf('fencedCode') + 1, 0, 'align_blocks')
+
+  const Compiler = this.Compiler
+
+  // Stringify
+  if (Compiler) {
+    const visitors = Compiler.prototype.visitors
+    const alignCompiler = function (node) {
+      const startMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '->',
+      }
+      const endMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '<-',
+      }
+      const innerString = this.all(node).join('')
+      const nodeAlignType = node.type.replace(/Aligned/, '')
+      const startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : ''
+      const endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : ''
+      return `${startMarker}\n${innerString}\n${endMarker}`
+    }
+    visitors.leftAligned = alignCompiler
+    visitors.rightAligned = alignCompiler
+    visitors.centerAligned = alignCompiler
+  }
 }


### PR DESCRIPTION
This PR should pass the in CI (except that I did not check the linter) but there is an issue :

in remark-align/src/index.php at line 125 I've got `new Compiler().all` because Compiler is a constructor.

According to documentation, I shall use `this` as the visitor is binded to the Compiler. 

If I do follow the documentation for that, I get an error :

```

    TypeError: _this.all is not a function

```