### PR TITLE
remark-align: Add Markdown compiler

### DIFF
--- a/packages/remark-align/.eslintrc.json
+++ b/packages/remark-align/.eslintrc.json
@@ -26,7 +26,7 @@
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
     "camelcase": [2, {"properties": "never"}],
-    "comma-dangle": [1, "always-multiline"],
+    "comma-dangle": [2, "always-multiline"],
     "comma-spacing": [2, {"before": false, "after": true}],
     "comma-style": [2, "last"],
     "computed-property-spacing": [2, "never"],

--- a/packages/remark-align/.eslintrc.json
+++ b/packages/remark-align/.eslintrc.json
@@ -26,7 +26,7 @@
     "block-spacing": [2, "always"],
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
     "camelcase": [2, {"properties": "never"}],
-    "comma-dangle": [2, "always-multiline"],
+    "comma-dangle": [1, "always-multiline"],
     "comma-spacing": [2, {"before": false, "after": true}],
     "comma-style": [2, "last"],
     "computed-property-spacing": [2, "never"],

--- a/packages/remark-align/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-align/__tests__/__snapshots__/index.js.snap
@@ -102,6 +102,26 @@ exports[`list-block 1`] = `
 </ul></div>"
 `;
 
+exports[`render md 1`] = `
+"# title
+
+<-
+ foo 
+<-
+
+# title
+
+->
+ **foo** 
+<-
+
+->
+  
+![img](src)
+->
+"
+`;
+
 exports[`right-no-end 1`] = `
 "<h1>title</h1>
 <p>-> foo</p>

--- a/packages/remark-align/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-align/__tests__/__snapshots__/index.js.snap
@@ -77,6 +77,29 @@ exports[`center-no-start 1`] = `
 <h1>title</h1>"
 `;
 
+exports[`compiles to markdown 1`] = `
+"# title
+
+<- foo <-
+
+# title
+
+-> **foo** <-
+
+-> ![img](src) ->
+
+# wraps blocks e.g. title:
+
+->
+foo
+
+# title
+
+foo
+->
+"
+`;
+
 exports[`escapable 1`] = `
 "<h1>title</h1>
 <div class=\\"align-center\\"><p>->escaped-in</p></div>
@@ -102,24 +125,16 @@ exports[`list-block 1`] = `
 </ul></div>"
 `;
 
-exports[`render md 1`] = `
-"# title
-
-<-
- foo 
-<-
-
-# title
-
-->
- **foo** 
-<-
-
-->
-  
-![img](src)
-->
-"
+exports[`no content 1`] = `
+"<div class=\\"align-left\\"></div>
+<div class=\\"align-left\\"></div>
+<div class=\\"align-center\\"></div>
+<div class=\\"align-center\\"></div>
+<div class=\\"align-center\\"></div>
+<div class=\\"align-right\\"></div>
+<div class=\\"align-right\\"></div>
+<div class=\\"align-right\\"></div>
+<div class=\\"align-right\\"></div>"
 `;
 
 exports[`right-no-end 1`] = `

--- a/packages/remark-align/__tests__/index.js
+++ b/packages/remark-align/__tests__/index.js
@@ -3,6 +3,7 @@ import unified from 'unified'
 import reParse from 'remark-parse'
 import stringify from 'rehype-stringify'
 import remark2rehype from 'remark-rehype'
+const remarkStringify = require('remark-stringify')
 
 import remarkAlign from '../src/'
 
@@ -12,6 +13,13 @@ const render = (text, config) => unified()
   .use(remark2rehype)
   .use(stringify)
   .processSync(text)
+
+const renderToMarkdown = (initialMarkdwon, config) => unified()
+  .use(reParse)
+  .use(remarkStringify)
+  .use(remarkAlign, config)
+  .processSync(initialMarkdwon)
+
 
 const alignFixture = dedent`
   Test align
@@ -163,6 +171,23 @@ test('left align', () => {
     <- foo <-
 
     # title
+  `)
+  expect(contents).toMatchSnapshot()
+})
+
+test('render md', () => {
+  const {contents} = renderToMarkdown(dedent`
+    # title
+
+    <- foo <-
+
+    # title
+    
+    -> **foo** <-
+    
+    ->  
+    ![img](src)
+    ->
   `)
   expect(contents).toMatchSnapshot()
 })

--- a/packages/remark-align/__tests__/index.js
+++ b/packages/remark-align/__tests__/index.js
@@ -14,11 +14,11 @@ const render = (text, config) => unified()
   .use(stringify)
   .processSync(text)
 
-const renderToMarkdown = (initialMarkdwon, config) => unified()
+const renderToMarkdown = (text, config) => unified()
   .use(reParse)
   .use(remarkStringify)
   .use(remarkAlign, config)
-  .processSync(initialMarkdwon)
+  .processSync(text)
 
 
 const alignFixture = dedent`
@@ -175,19 +175,70 @@ test('left align', () => {
   expect(contents).toMatchSnapshot()
 })
 
-test('render md', () => {
-  const {contents} = renderToMarkdown(dedent`
+test('no content', () => {
+  const md = dedent`
+    <- <-
+
+    <-
+
+    <-
+
+    -> <-
+
+    -><-
+
+    ->
+
+    <-
+
+    ->->
+
+    ->  ->
+
+    ->
+    ->
+
+    ->
+
+    ->
+  `
+
+  const {contents} = render(md)
+  expect(contents).toMatchSnapshot()
+
+  const contents1 = renderToMarkdown(md).contents
+  const contents2 = renderToMarkdown(contents1).contents
+
+  expect(contents1).toBe(contents2)
+})
+
+test('compiles to markdown', () => {
+  const md = dedent`
     # title
 
     <- foo <-
 
     # title
-    
+
     -> **foo** <-
-    
-    ->  
+
+    ->
     ![img](src)
     ->
-  `)
+
+    # wraps blocks e.g. title:
+
+    -> foo
+
+    # title
+
+    foo ->
+  `
+  const {contents} = renderToMarkdown(md)
   expect(contents).toMatchSnapshot()
+
+  const contents1 = renderToMarkdown(md).contents
+  const contents2 = renderToMarkdown(contents1).contents
+
+  expect(contents1).toBe(contents2)
 })

--- a/packages/remark-align/dist/index.js
+++ b/packages/remark-align/dist/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 var spaceSeparated = require('space-separated-tokens');
 
 var C_NEWLINE = '\n';
@@ -111,21 +113,24 @@ module.exports = function plugin() {
   if (Compiler) {
     var visitors = Compiler.prototype.visitors;
     var alignCompiler = function alignCompiler(node) {
-      var startMarkersMap = {
-        'left': '<-',
-        'right': '->',
-        'center': '->'
+      var innerContent = this.all(node);
+
+      var markers = {
+        left: ['<-', '<-'],
+        right: ['->', '->'],
+        center: ['->', '<-']
       };
-      var endMarkersMap = {
-        'left': '<-',
-        'right': '->',
-        'center': '<-'
-      };
-      var innerString = this.all(node).join('');
-      var nodeAlignType = node.type.replace(/Aligned/, '');
-      var startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : '';
-      var endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : '';
-      return startMarker + '\n' + innerString + '\n' + endMarker;
+      var alignType = node.type.slice(0, -7);
+
+      if (!markers[alignType]) return innerContent.join('\n\n');
+
+      var _markers$alignType = _slicedToArray(markers[alignType], 2),
+          start = _markers$alignType[0],
+          end = _markers$alignType[1];
+
+      if (innerContent.length < 2) return start + ' ' + innerContent.join('\n').trim() + ' ' + end;
+
+      return start + '\n' + innerContent.join('\n\n').trim() + '\n' + end;
     };
     visitors.leftAligned = alignCompiler;
     visitors.rightAligned = alignCompiler;

--- a/packages/remark-align/dist/index.js
+++ b/packages/remark-align/dist/index.js
@@ -104,4 +104,31 @@ module.exports = function plugin() {
   var blockMethods = Parser.prototype.blockMethods;
   blockTokenizers.align_blocks = alignTokenizer;
   blockMethods.splice(blockMethods.indexOf('fencedCode') + 1, 0, 'align_blocks');
+
+  var Compiler = this.Compiler;
+
+  // Stringify
+  if (Compiler) {
+    var visitors = Compiler.prototype.visitors;
+    var alignCompiler = function alignCompiler(node) {
+      var startMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '->'
+      };
+      var endMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '<-'
+      };
+      var innerString = this.all(node).join('');
+      var nodeAlignType = node.type.replace(/Aligned/, '');
+      var startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : '';
+      var endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : '';
+      return startMarker + '\n' + innerString + '\n' + endMarker;
+    };
+    visitors.leftAligned = alignCompiler;
+    visitors.rightAligned = alignCompiler;
+    visitors.centerAligned = alignCompiler;
+  }
 };

--- a/packages/remark-align/package.json
+++ b/packages/remark-align/package.json
@@ -46,6 +46,7 @@
     "rehype-stringify": "^3.0.0",
     "remark-parse": "^5.0.0",
     "remark-rehype": "^3.0.0",
+    "remark-stringify": "^5.0.0",
     "unified": "^6.1.5"
   }
 }

--- a/packages/remark-align/src/index.js
+++ b/packages/remark-align/src/index.js
@@ -112,21 +112,22 @@ module.exports = function plugin (classNames = {}) {
   if (Compiler) {
     const visitors = Compiler.prototype.visitors
     const alignCompiler = function (node) {
-      const startMarkersMap = {
-        'left': '<-',
-        'right': '->',
-        'center': '->',
+      const innerContent = this.all(node)
+
+      const markers = {
+        left: ['<-', '<-'],
+        right: ['->', '->'],
+        center: ['->', '<-'],
       }
-      const endMarkersMap = {
-        'left': '<-',
-        'right': '->',
-        'center': '<-',
-      }
-      const innerString = this.all(node).join('')
-      const nodeAlignType = node.type.replace(/Aligned/, '')
-      const startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : ''
-      const endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : ''
-      return `${startMarker}\n${innerString}\n${endMarker}`
+      const alignType = node.type.slice(0, -7)
+
+      if (!markers[alignType]) return innerContent.join('\n\n')
+
+      const [start, end] = markers[alignType]
+
+      if (innerContent.length < 2) return `${start} ${innerContent.join('\n').trim()} ${end}`
+
+      return `${start}\n${innerContent.join('\n\n').trim()}\n${end}`
     }
     visitors.leftAligned = alignCompiler
     visitors.rightAligned = alignCompiler

--- a/packages/remark-align/src/index.js
+++ b/packages/remark-align/src/index.js
@@ -105,4 +105,31 @@ module.exports = function plugin (classNames = {}) {
   const blockMethods = Parser.prototype.blockMethods
   blockTokenizers.align_blocks = alignTokenizer
   blockMethods.splice(blockMethods.indexOf('fencedCode') + 1, 0, 'align_blocks')
+
+  const Compiler = this.Compiler
+
+  // Stringify
+  if (Compiler) {
+    const visitors = Compiler.prototype.visitors
+    const alignCompiler = function (node) {
+      const startMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '->',
+      }
+      const endMarkersMap = {
+        'left': '<-',
+        'right': '->',
+        'center': '<-',
+      }
+      const innerString = this.all(node).join('')
+      const nodeAlignType = node.type.replace(/Aligned/, '')
+      const startMarker = nodeAlignType in startMarkersMap ? startMarkersMap[nodeAlignType] : ''
+      const endMarker = nodeAlignType in endMarkersMap ? endMarkersMap[nodeAlignType] : ''
+      return `${startMarker}\n${innerString}\n${endMarker}`
+    }
+    visitors.leftAligned = alignCompiler
+    visitors.rightAligned = alignCompiler
+    visitors.centerAligned = alignCompiler
+  }
 }


### PR DESCRIPTION
`join('')` would break block content, for instance

```
foo
# title
```

should not become `foo# title`.

2nd commit fixes this and reverts changes in linting config. I also added a test to make sure compiling to Markdown is stable (i.e. compiling n times always yields the same result).