### PR TITLE
Feature to use tags details and summary with rehype

### DIFF
--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -64,6 +64,11 @@ unified()
       classes: 'qux-block',
       title: 'required'
     },
+    spoiler: {
+      classes: 'spoiler-block',
+      title: 'optional',
+      details: true
+    },
   })
   .use(remark2rehype)
   .use(stringify)
@@ -85,6 +90,9 @@ The sample configuration provided above would have the following effect:
 
     [[qux | my title]]
     | content
+
+    [[spoiler | my title]]
+    | content
     ```
 
     * Block `foo` cannot have a title, `[[foo | title]]` will not result in a block.
@@ -97,7 +105,7 @@ The sample configuration provided above would have the following effect:
     * `barCustomBlock`, content in `barCustomBlockBody`, optional title in `barCustomBlockHeading`
     * `quxCustomBlock`, content in `quxCustomBlockBody`, required title in `quxCustomBlockHeading`
 
-1. If you're using [rehype][rehype], you will end up with these 4 `div`s:
+1. If you're using [rehype][rehype], you will end up with these 4 `div`s and 1 `details`:
 
     ```html
     <div class="custom-block a-class another-class">
@@ -117,7 +125,12 @@ The sample configuration provided above would have the following effect:
       <div class="custom-block-heading">my title</div>
       <div class="custom-block-body"><p>content</p></div>
     </div>
-    ```
+
+     <details class="custom-block spoiler-block">
+      <summary class="custom-block-heading">my title</summary>
+      <div class="custom-block-body"><p>content</p></div>
+    </details>
+   ```
 
 ## License
 

--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -48,6 +48,11 @@ const render = (text, allowTitle) => unified()
       classes: 'neutral foo',
       title: 'optional',
     },
+    details: {
+      classes: 'spoiler',
+      title: 'optional',
+      details: true,
+    },
   }, allowTitle)
   .use(stringify)
   .processSync(text)
@@ -137,6 +142,19 @@ test('title is optional', () => {
     | yes
   `)
   expect(contents).toMatchSnapshot()
+})
+
+test('details', () => {
+  const {contents} = render(dedent`
+    [[details| my title]]
+    | content
+  `)
+
+  expect(contents).toBe(dedent`
+    <details class="custom-block spoiler">\
+    <summary class="custom-block-heading">my title</summary>\
+    <div class="custom-block-body"><p>content</p></div>\
+    </details>`)
 })
 
 test('Errors without config', () => {

--- a/packages/remark-custom-blocks/dist/index.js
+++ b/packages/remark-custom-blocks/dist/index.js
@@ -87,7 +87,7 @@ module.exports = function blockPlugin() {
       var titleNode = {
         type: blockType + 'CustomBlockHeading',
         data: {
-          hName: 'div',
+          hName: potentialBlock.details ? 'summary' : 'div',
           hProperties: {
             className: 'custom-block-heading'
           }
@@ -103,7 +103,7 @@ module.exports = function blockPlugin() {
       type: blockType + 'CustomBlock',
       children: blockChildren,
       data: {
-        hName: 'div',
+        hName: potentialBlock.details ? 'details' : 'div',
         hProperties: {
           className: ['custom-block'].concat(_toConsumableArray(classList))
         }

--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -77,7 +77,7 @@ module.exports = function blockPlugin (availableBlocks = {}) {
       const titleNode = {
         type: `${blockType}CustomBlockHeading`,
         data: {
-          hName: 'div',
+          hName: potentialBlock.details ? 'summary' : 'div',
           hProperties: {
             className: 'custom-block-heading',
           },
@@ -93,7 +93,7 @@ module.exports = function blockPlugin (availableBlocks = {}) {
       type: `${blockType}CustomBlock`,
       children: blockChildren,
       data: {
-        hName: 'div',
+        hName: potentialBlock.details ? 'details' : 'div',
         hProperties: {
           className: ['custom-block', ...classList],
         },


### PR DESCRIPTION
See issue #228

https://github.com/zestedesavoir/zmarkdown/issues/228

Their is a test and a README modification.