### PR TITLE
zmarkdown: fix image & one smiley

### DIFF
--- a/packages/remark-emoticons/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-emoticons/__tests__/__snapshots__/index.js.snap
@@ -32,6 +32,13 @@ exports[`emoticons without class 1`] = `
 <p>Smiley after another node w/3 spaces: <a href=\\"#foo\\">link</a>   <img src=\\"/static/smileys/smile.png\\" alt=\\":)\\"></p>"
 `;
 
+exports[`renders case insensitive 1`] = `
+"<p><img src=\\"/static/smileys/langue.png\\" alt=\\":p\\"> is same as <img src=\\"/static/smileys/langue.png\\" alt=\\":P\\"></p>
+<p><img src=\\"/static/smileys/heureux.png\\" alt=\\":d\\"> is same as <img src=\\"/static/smileys/heureux.png\\" alt=\\":D\\"></p>
+<p><img src=\\"/static/smileys/blink.gif\\" alt=\\"o_O\\"> is same as <img alt=\\"o_o\\"> and <img alt=\\"O_O\\"></p>
+<p><img src=\\"/static/smileys/magicien.png\\" alt=\\":magicien:\\"> is same as <img src=\\"/static/smileys/magicien.png\\" alt=\\":MAGICIEN:\\"> and as <img src=\\"/static/smileys/magicien.png\\" alt=\\":mAgIcIeN:\\"></p>"
+`;
+
 exports[`renders to markdown 1`] = `
 "Hello :) Hey :D
 

--- a/packages/remark-emoticons/__tests__/index.js
+++ b/packages/remark-emoticons/__tests__/index.js
@@ -155,3 +155,25 @@ test('renders to markdown', () => {
   const recompiled = renderToMarkdown(contents).contents
   expect(recompiled).toBe(contents)
 })
+
+test('renders case insensitive', () => {
+  const render = text => unified()
+    .use(reParse)
+    .use(plugin, config)
+    .use(remark2rehype)
+    .use(stringify)
+    .processSync(text)
+
+  delete config.classes
+
+  const {contents} = render(dedent`
+    :p is same as :P
+    
+    :d is same as :D
+    
+    o_O is same as o_o and O_O
+    
+    :magicien: is same as :MAGICIEN: and as :mAgIcIeN:
+  `)
+  expect(contents).toMatchSnapshot()
+})

--- a/packages/remark-emoticons/dist/index.js
+++ b/packages/remark-emoticons/dist/index.js
@@ -15,7 +15,7 @@ module.exports = function inlinePlugin(ctx) {
     throw new Error('remark-emoticons needs to be passed a configuration object as option');
   }
 
-  var regex = new RegExp('(\\s|^)(' + pattern + ')(\\s|$)');
+  var regex = new RegExp('(\\s|^)(' + pattern + ')(\\s|$)', 'i');
 
   function locator(value, fromIndex) {
     var keep = regex.exec(value);
@@ -36,13 +36,14 @@ module.exports = function inlinePlugin(ctx) {
         toEat = toEat.substring(0, toEat.length - 1);
       }
       var emoticon = toEat.trim();
+      var src = emoticons[emoticon] || emoticons[emoticon.toLowerCase()] || emoticons[emoticon.toUpperCase()];
       var emoticonNode = {
         type: 'emoticon',
         value: emoticon,
         data: {
           hName: 'img',
           hProperties: {
-            src: emoticons[emoticon],
+            src: src,
             alt: emoticon
           }
         }

--- a/packages/remark-emoticons/src/index.js
+++ b/packages/remark-emoticons/src/index.js
@@ -13,7 +13,7 @@ module.exports = function inlinePlugin (ctx) {
     throw new Error('remark-emoticons needs to be passed a configuration object as option')
   }
 
-  const regex = new RegExp(`(\\s|^)(${pattern})(\\s|$)`)
+  const regex = new RegExp(`(\\s|^)(${pattern})(\\s|$)`, 'i')
 
   function locator (value, fromIndex) {
     const keep = regex.exec(value)
@@ -34,13 +34,15 @@ module.exports = function inlinePlugin (ctx) {
         toEat = toEat.substring(0, toEat.length - 1)
       }
       const emoticon = toEat.trim()
+      const src = (emoticons[emoticon] || emoticons[emoticon.toLowerCase()] ||
+        emoticons[emoticon.toUpperCase()])
       const emoticonNode = {
         type: 'emoticon',
         value: emoticon,
         data: {
           hName: 'img',
           hProperties: {
-            src: emoticons[emoticon],
+            src: src,
             alt: emoticon,
           },
         },

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -501,7 +501,7 @@ multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|c|}{
 
 \\\\begin{longtabu}{|p{\\\\linewidth / 2}|p{\\\\linewidth / 2}|} \\\\hline
 title & image \\\\\\\\ \\\\hline
-space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\ \\\\hline
+space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 

--- a/packages/zmarkdown/__tests__/__snapshots__/new-html-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/new-html-suite.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`images does transform inline images into figures 1`] = `"<p>one image <img src=\\"http://blabla.fr\\" alt=\\"not wrapped into figure because inline\\"> car inline</p>"`;
+
+exports[`images transform block images into figures 1`] = `
+"<p>one image</p>
+<figure><img src=\\"http://blabla.fr\\" alt=\\"wrapped into figure\\"><figcaption>wrapped into figure</figcaption></figure>"
+`;

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -2793,8 +2793,7 @@ exports[`#misc properly renders h1.txt 1`] = `
 `;
 
 exports[`#misc properly renders image.txt 1`] = `
-"\\\\image{http://humane_man.jpg}
-
+"\\\\image{http://humane_man.jpg}[Poster]
 
 
 \\\\image{http://humane_man.jpg}
@@ -2803,7 +2802,7 @@ exports[`#misc properly renders image.txt 1`] = `
 
 \\\\footnote{\\\\label{poster}\\\\externalLink{http://humane\\\\_man.jpg}{http://humane\\\\_man.jpg}}
 
-\\\\image{}"
+\\\\image{}[Blank]"
 `;
 
 exports[`#misc properly renders image_in_links.txt 1`] = `"\\\\externalLink{\\\\image{path/to/img_thumb.png}}{path/to/image.png}"`;
@@ -4116,8 +4115,7 @@ Ce n'est pas une légende
 
 
 
-\\\\image{https://zestedesavoir.com/media/galleries/3014/bee33fae-2216-463a-8b85-d1d9efe2c374.png}
-
+\\\\image{https://zestedesavoir.com/media/galleries/3014/bee33fae-2216-463a-8b85-d1d9efe2c374.png}[toto]
 
 
 ce n'est pas une légende non plus"

--- a/packages/zmarkdown/__tests__/fixtures/misc/image.html
+++ b/packages/zmarkdown/__tests__/fixtures/misc/image.html
@@ -1,3 +1,3 @@
+<figure><img src="http://humane_man.jpg" alt="Poster" title="The most humane man."><figcaption>Poster</figcaption></figure>
 <p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man."></p>
-<p><img alt="Poster" src="http://humane_man.jpg" title="The most humane man."></p>
-<p><img alt="Blank" src=""></p>
+<figure><img src="" alt="Blank"><figcaption>Blank</figcaption></figure>

--- a/packages/zmarkdown/__tests__/fixtures/zds/extensions/emoticons.html
+++ b/packages/zmarkdown/__tests__/fixtures/zds/extensions/emoticons.html
@@ -4,5 +4,5 @@
 <p>Citation</p>
 </blockquote>
 <p><img alt=":D" src="/static/smileys/heureux.png" class="smiley"> Ce n'est pas une légende</p>
-<p><img alt="toto" src="https://zestedesavoir.com/media/galleries/3014/bee33fae-2216-463a-8b85-d1d9efe2c374.png"></p>
+<figure><img src="https://zestedesavoir.com/media/galleries/3014/bee33fae-2216-463a-8b85-d1d9efe2c374.png" alt="toto"><figcaption>toto</figcaption></figure>
 <p><img alt=":D" src="/static/smileys/heureux.png" class="smiley"> ce n'est pas une légende non plus</p>

--- a/packages/zmarkdown/__tests__/new-html-suite.test.js
+++ b/packages/zmarkdown/__tests__/new-html-suite.test.js
@@ -150,3 +150,20 @@ describe('tables', () => {
     return expect(renderString(input)).resolves.toContain('<td><code>gauche \\| droite</code></td>')
   })
 })
+
+describe('images', () => {
+  it('transform block images into figures', () => {
+    const input = dedent`
+    one image
+    
+    ![wrapped into figure](http://blabla.fr)
+    `
+    return expect(renderString(input)).resolves.toMatchSnapshot()
+  })
+  it('does transform inline images into figures', () => {
+    const input = dedent`
+    one image ![not wrapped into figure because inline](http://blabla.fr) car inline
+    `
+    return expect(renderString(input)).resolves.toMatchSnapshot()
+  })
+})

--- a/packages/zmarkdown/config/remark.js
+++ b/packages/zmarkdown/config/remark.js
@@ -294,7 +294,6 @@ const remarkConfig = {
       },
     },
   },
-
   captions: {
     external: {
       table: 'Table:',

--- a/packages/zmarkdown/index.js
+++ b/packages/zmarkdown/index.js
@@ -70,6 +70,32 @@ const wrappers = {
   ],
 }
 
+const imageToFigure = (img, index, parent) => {
+  if (parent.children.length === 1 && parent.type === 'paragraph') {
+    if (!img.alt) {
+      return
+    }
+    const figureCaptionNode = {
+      type: 'figcaption',
+      children: [
+        {
+          type: 'text',
+          value: img.alt,
+        },
+      ],
+      data: {
+        hName: 'figcaption',
+      },
+    }
+    parent.type = 'figure'
+    parent.children = [clone(img), figureCaptionNode]
+    parent.data = {
+      hName: 'figure',
+    }
+  }
+}
+
+
 const zmdParser = (config, target) => {
   const mdProcessor = unified()
     .use(remarkParse, config.reParse)
@@ -99,6 +125,8 @@ const zmdParser = (config, target) => {
     .use(remarkSubSuper)
     .use(remarkTrailingSpaceHeading)
     .use(() => (tree, vfile) => {
+      // implement old functionality that transforms block images into figure
+      visit(tree, 'image', imageToFigure)
       /* extract some metadata for frontends */
 
       // if we don't have any headings, we add a flag to disable

--- a/packages/zmarkdown/index.js
+++ b/packages/zmarkdown/index.js
@@ -109,7 +109,7 @@ const zmdParser = (config, target) => {
     .use(remarkAbbr)
     .use(remarkAlign, config.alignBlocks)
     .use(remarkCaptions, config.captions)
-    .use(remarkComments)
+    .use(remarkComments, config.comments)
     .use(remarkCustomBlocks, config.customBlocks)
     .use(remarkDisableTokenizers, config.disableTokenizers)
     .use(remarkEmoticons, config.emoticons)


### PR DESCRIPTION
Since v27 deployment we got some feedback, this PR fixes two of them :

- we cannot use `:P` anymore
- when we use image figures are not created. (fix #420)