### PR TITLE
remark-images-download: handle invalid URLs

### DIFF
--- a/packages/remark-images-download/__tests__/index.js
+++ b/packages/remark-images-download/__tests__/index.js
@@ -42,6 +42,16 @@ const r = (html) => html.replace(
   'foo/bar')
 
 describe('mock server tests', () => {
+  test('rejects invalid URLs', () => {
+    const file = '![foo](http://%99:%99@example.com)'
+
+    const render = renderFactory()
+
+    return render(file).then(vfile => {
+      expect(firstMsg(vfile)).toBe('Invalid URL: http://%99:%99@example.com')
+    })
+  })
+
   test('downloads image ok', () => {
     const file = dedent`
       ![](http://localhost:27273/test.svg)

--- a/packages/remark-images-download/dist/index.js
+++ b/packages/remark-images-download/dist/index.js
@@ -96,7 +96,13 @@ function plugin() {
         var url = node.url,
             position = node.position;
 
-        var parsedURI = URL.parse(url);
+        var parsedURI = void 0;
+        try {
+          parsedURI = URL.parse(url);
+        } catch (error) {
+          vfile.message('Invalid URL: ' + url, position, url);
+          return;
+        }
 
         var extension = path.extname(parsedURI.pathname);
         var filename = '' + shortid.generate() + extension;

--- a/packages/remark-images-download/src/index.js
+++ b/packages/remark-images-download/src/index.js
@@ -78,7 +78,13 @@ function plugin ({
 
         visit(tree, 'image', (node) => {
           const {url, position} = node
-          const parsedURI = URL.parse(url)
+          let parsedURI
+          try {
+            parsedURI = URL.parse(url)
+          } catch (error) {
+            vfile.message(`Invalid URL: ${url}`, position, url)
+            return
+          }
 
           const extension = path.extname(parsedURI.pathname)
           const filename = `${shortid.generate()}${extension}`


### PR DESCRIPTION
There are some special malformed URLs like `http://%99:%99@example.com` that `url.parse` can’t decode.