### PR TITLE
fix(remark-iframes): Fix youtube link client side

### DIFF
--- a/packages/zmarkdown/config/remark.js
+++ b/packages/zmarkdown/config/remark.js
@@ -221,7 +221,6 @@ const remarkConfig = {
         format: 'http://img.youtube.com/vi/{id}/0.jpg',
         id: '.+/(.+)$',
       },
-      droppedQueryParameters: ['feature'],
       removeAfter: '&',
     },
     'youtube.com': {
@@ -237,7 +236,6 @@ const remarkConfig = {
         format: 'http://img.youtube.com/vi/{id}/0.jpg',
         id: '.+/(.+)$',
       },
-      droppedQueryParameters: ['feature'],
       removeAfter: '&',
     },
     'youtu.be': {
@@ -253,7 +251,6 @@ const remarkConfig = {
         format: 'http://img.youtube.com/vi/{id}/0.jpg',
         id: '.+/(.+)$',
       },
-      droppedQueryParameters: ['feature'],
       removeAfter: '&',
     },
     'www.ina.fr': {


### PR DESCRIPTION
Due to portage of remark-iframes from python version.
In python the parameter feature was deleted from URL.
This cause trouble on the client.