### PR TITLE
fix(smiley): fix >_< smiley at the beginning of the paragraph

### DIFF
--- a/packages/zmarkdown/__tests__/__snapshots__/new-html-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/new-html-suite.test.js.snap
@@ -34,7 +34,17 @@ exports[`pedantic mode disabled unordered lists markers 1`] = `
 </ul>"
 `;
 
+exports[`smileys translates :>_<: 1`] = `"<p>This is funny <img src=\\"/static/smileys/pinch.png\\" alt=\\":>_<:\\" class=\\"smiley\\"></p>"`;
+
+exports[`smileys translates :>_<: at the beginning of the paragraph 1`] = `"<p><img src=\\"/static/smileys/pinch.png\\" alt=\\":>_<:\\" class=\\"smiley\\"></p>"`;
+
 exports[`smileys translates >_< 1`] = `"<p>This is funny <img src=\\"/static/smileys/pinch.png\\" alt=\\">_<\\" class=\\"smiley\\"></p>"`;
+
+exports[`smileys translates >_< at the beginning of the paragraph 1`] = `
+"<blockquote>
+<p>_&#x3C;</p>
+</blockquote>"
+`;
 
 exports[`smileys translates X/ 1`] = `"<p>This is funny <img src=\\"/static/smileys/pinch.png\\" alt=\\"X/\\" class=\\"smiley\\"></p>"`;
 

--- a/packages/zmarkdown/__tests__/new-html-suite.test.js
+++ b/packages/zmarkdown/__tests__/new-html-suite.test.js
@@ -228,6 +228,24 @@ describe('smileys', () => {
     return expect(renderString(input)).resolves.toMatchSnapshot()
   })
 
+  it(`translates :>_<:`, () => {
+    const input = 'This is funny :>_<:'
+
+    return expect(renderString(input)).resolves.toMatchSnapshot()
+  })
+
+  it(`translates >_< at the beginning of the paragraph`, () => {
+    const input = '>_<'
+
+    return expect(renderString(input)).resolves.toMatchSnapshot()
+  })
+
+  it(`translates :>_<: at the beginning of the paragraph`, () => {
+    const input = ':>_<:'
+
+    return expect(renderString(input)).resolves.toMatchSnapshot()
+  })
+
   it(`translates X/`, () => {
     const input = 'This is funny X/'
 

--- a/packages/zmarkdown/config/remark.js
+++ b/packages/zmarkdown/config/remark.js
@@ -148,6 +148,7 @@ const remarkConfig = {
       ':ninja:': '/static/smileys/ninja.png',
       'x(': '/static/smileys/pinch.png',
       '>_<': '/static/smileys/pinch.png',
+      ':>_<:': '/static/smileys/pinch.png',
       'X/': '/static/smileys/pinch.png',
       ':pirate:': '/static/smileys/pirate.png',
       ":'(": '/static/smileys/pleure.png',


### PR DESCRIPTION
`>_<` smiley have now an alternate way to display it: `:>_<:`.
This allow to start a paragraph with this smiley and to not collide with:
- CommonMark spec: [example 192](https://spec.commonmark.org/0.28/#example-192)
- GFM spec: [Example 200](https://github.github.com/gfm/#example-200)

Fix #281