### PR TITLE
remark-grid-tables: preserve spaces on `before` lines

### DIFF
--- a/packages/remark-grid-tables/__tests__/index.js
+++ b/packages/remark-grid-tables/__tests__/index.js
@@ -89,6 +89,29 @@ test('regression: should be parsed with two spaces on last line', () => {
   expect(contents).toBe(base)
 })
 
+test('regression: should not crash with leading space', () => {
+  const {contents: base} = render(dedent`
+    ax
+    +---+
+    | b |
+    +---+
+
+    hello
+    `)
+
+  const {contents} = render(dedent`
+    a·
+    +---+
+    | b |
+    +---+
+
+    hello
+    `.replace(/·/g, ' '))
+
+  expect(contents).toBe(base.replace('x', ' '))
+})
+
+
 test('stringify', () => {
   const fileExample = file(join(__dirname, 'grid-tables.md'))
   const {contents} = render(fileExample)

--- a/packages/remark-grid-tables/dist/index.js
+++ b/packages/remark-grid-tables/dist/index.js
@@ -271,18 +271,20 @@ function computeColumnStartingPositions(lines) {
 
 function extractTable(value, eat, tokenizer) {
   // Extract lines before the grid table
-  var possibleGridTable = value.split('\n').map(function (line) {
-    return trimEnd(line);
-  });
+  var markdownLines = value.split('\n');
 
   var i = 0;
   var before = [];
-  for (; i < possibleGridTable.length; i++) {
-    var line = possibleGridTable[i];
+  for (; i < markdownLines.length; i++) {
+    var line = markdownLines[i];
     if (isSeparationLine(line)) break;
     if (line.length === 0) break;
     before.push(line);
   }
+
+  var possibleGridTable = markdownLines.map(function (line) {
+    return trimEnd(line);
+  });
 
   // Extract table
   if (!possibleGridTable[i + 1]) return [null, null, null, null];

--- a/packages/remark-grid-tables/src/index.js
+++ b/packages/remark-grid-tables/src/index.js
@@ -227,18 +227,20 @@ function computeColumnStartingPositions (lines) {
 
 function extractTable (value, eat, tokenizer) {
   // Extract lines before the grid table
-  const possibleGridTable = value
+  const markdownLines = value
     .split('\n')
-    .map(line => trimEnd(line))
 
   let i = 0
   const before = []
-  for (; i < possibleGridTable.length; i++) {
-    const line = possibleGridTable[i]
+  for (; i < markdownLines.length; i++) {
+    const line = markdownLines[i]
     if (isSeparationLine(line)) break
     if (line.length === 0) break
     before.push(line)
   }
+
+  const possibleGridTable = markdownLines
+    .map(line => trimEnd(line))
 
   // Extract table
   if (!possibleGridTable[i + 1]) return [null, null, null, null]


### PR DESCRIPTION
I think I got it. Way easier than I thought. Please review @AmarOk1412 , please also think about edge cases this PR might break?