### PR TITLE
remark-abbr: remove empty p children in correct order

### DIFF
--- a/packages/remark-abbr/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-abbr/__tests__/__snapshots__/index.js.snap
@@ -9,6 +9,8 @@ exports[`compiles to markdown 1`] = `
 *[HTML]: HyperText Markup Language"
 `;
 
+exports[`does not break with references in their own paragraphs 1`] = `"<p>Here is a test featuring <abbr title=\\"A B C\\">abc</abbr> and <abbr title=\\"D E F\\">def</abbr></p>"`;
+
 exports[`no reference 1`] = `"<p>No reference!</p>"`;
 
 exports[`passes the first regression test 1`] = `

--- a/packages/remark-abbr/__tests__/index.js
+++ b/packages/remark-abbr/__tests__/index.js
@@ -155,3 +155,15 @@ it('does not parse words containing abbr', () => {
 
   expect(contents).not.toContain('<abbr')
 })
+
+it('does not break with references in their own paragraphs', () => {
+  const {contents} = render(dedent`
+    Here is a test featuring abc and def
+
+    *[abc]: A B C
+
+    *[def]: D E F
+  `)
+
+  expect(contents).toMatchSnapshot()
+})


### PR DESCRIPTION
Previously when we had to remove parent.children[17] and parent.children[21] we would
parent.children.splice(17, 1) and then parent.children.splice(21, 1), this later call removing
index 20 from the original parent.children since it got shifted by any previous .splice call.

#289