### PR TITLE
zmarkdown: Add statistics facility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2361,9 +2361,9 @@
       }
     },
     "@pm2/agent": {
-      "version": "0.5.24",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.24.tgz",
-      "integrity": "sha512-j6lJMMmGvDvxcyPBO3JpqdSdzlQUlWDSfVRWzLSHKioEUMYeq/JBx3ZQmA1D25OoDPzaymwcquP4B0HR6gU1bQ==",
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-0.5.26.tgz",
+      "integrity": "sha512-pqiS87IiUprkSR7SG0RKMATuYXl4QjH1tSSUwM4wJcovRT4pD5dvnnu61w9y/4/Ur5V/+a7bqS8bZz51y3U2iA==",
       "requires": {
         "async": "^2.6.0",
         "chalk": "^2.3.2",
@@ -2373,35 +2373,59 @@
         "nssocket": "^0.6.0",
         "pm2-axon": "^3.2.0",
         "pm2-axon-rpc": "^0.5.0",
+        "proxy-agent": "^3.1.0",
         "semver": "^5.5.0",
         "ws": "^5.1.0"
       }
     },
     "@pm2/js-api": {
-      "version": "0.5.55",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.55.tgz",
-      "integrity": "sha512-GWqSs1ewTOgIaOb+WKyKF+R7qMfMxHLM06WIMa9TBwab7YtVedTTrk0ObsK/NAAmrFk0/eefFRu/ouoh4ICDxw==",
+      "version": "0.5.60",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.5.60.tgz",
+      "integrity": "sha512-CvAbpIB7ObOuwvqhDBB/E4Z4ANRx2dBk08zYpGPNg+1fDj14FJg2e7DWA8bblSGNC8QarIXPaqPDJBL1e8cRQw==",
       "requires": {
         "async": "^2.4.1",
-        "axios": "^0.16.2",
+        "axios": "^0.19.0",
         "debug": "^2.6.8",
         "eventemitter2": "^4.1.0",
         "ws": "^3.0.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.16.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-          "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+          "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
           "requires": {
-            "follow-redirects": "^1.2.3",
-            "is-buffer": "^1.1.5"
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
           }
         },
         "eventemitter2": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
           "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         },
         "ws": {
           "version": "3.3.3",
@@ -3021,9 +3045,9 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
-      "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA=="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.1.tgz",
+      "integrity": "sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ=="
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -5024,9 +5048,9 @@
       }
     },
     "cron": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.0.tgz",
-      "integrity": "sha512-I7S7ES2KZtKPfBTGJ5Brc6X23apE71fgYU/PC5ayh8R6VhECpqvTLe/LTkwAEN3ERFzNKXlWzh/PkwsGg3vkDQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.1.tgz",
+      "integrity": "sha512-gmMB/pJcqUVs/NklR1sCGlNYM7TizEw+1gebz20BMc/8bTm/r7QUp3ZPSPlG8Z5XRlvb7qhjEjq/+bdIfUCL2A==",
       "requires": {
         "moment-timezone": "^0.5.x"
       }
@@ -5146,9 +5170,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
-          "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ=="
+          "version": "8.10.49",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
+          "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w=="
         }
       }
     },
@@ -6183,9 +6207,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fault": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
-      "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
       "requires": {
         "format": "^0.2.2"
       }
@@ -6445,6 +6469,7 @@
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
       "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -6453,6 +6478,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -7186,14 +7212,14 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7840,9 +7866,9 @@
       }
     },
     "hast-util-has-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.2.tgz",
-      "integrity": "sha512-EBzRiKIIe9wouLSjqun5ti0oYcEe5U1eEpuOPtcihmP3KvFRovOmmXypf1B/QalQr9S4YoVgLOSg6gW98ihRbA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.3.tgz",
+      "integrity": "sha512-tT3ffSnrBu38RKnjn27n9vi+h/CUEXCQP5O2mriji4NNI2QNnhAqefjOg5ORAyvVfJItn0SC2Sx4CHReZSYh3g=="
     },
     "hast-util-is-element": {
       "version": "1.0.2",
@@ -7850,9 +7876,9 @@
       "integrity": "sha512-4MEtyofNi3ZunPFrp9NpTQdNPN24xvLX3M+Lr/RGgPX6TLi+wR4/DqeoyQ7lwWcfUp4aevdt4RR0r7ZQPFbHxw=="
     },
     "hast-util-parse-selector": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz",
-      "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.2.tgz",
+      "integrity": "sha512-jIMtnzrLTjzqgVEQqPEmwEZV+ea4zHRFTP8Z2Utw0I5HuBOXHzUPPQWr6ouJdJqDKLbFU/OEiYwZ79LalZkmmw=="
     },
     "hast-util-sanitize": {
       "version": "1.3.0",
@@ -7890,9 +7916,9 @@
       }
     },
     "hast-util-to-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.1.tgz",
-      "integrity": "sha512-EC6awGe0ZMUNYmS2hMVaKZxvjVtQA4RhXjtgE20AxGG49MM7OUUfaHc6VcVYv2YwzNlrZQGe5teimCxW1Rk+fA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.2.tgz",
+      "integrity": "sha512-fQNr0n5KJmZW1TmBfXbc4DO0ucZmseUw3T6K4PDsUUTMtTGGLZMUYRB8mOKgPgtw7rtICdxxpRQZmWwo8KxlOA=="
     },
     "hast-util-whitespace": {
       "version": "1.0.2",
@@ -7912,9 +7938,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.15.6",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
+      "version": "9.15.8",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -9097,8 +9123,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9141,8 +9166,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -9153,8 +9177,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9271,8 +9294,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9284,7 +9306,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9307,14 +9328,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9333,7 +9352,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9414,8 +9432,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9427,7 +9444,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9513,8 +9529,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9550,7 +9565,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9570,7 +9584,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9614,14 +9627,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         }
@@ -10512,9 +10523,9 @@
       "dev": true
     },
     "lowlight": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.0.tgz",
-      "integrity": "sha512-SRlH+ajYbZCE2cDIBC+XJHKxQjTuf+h8k6BwNYMpBRBXkoy5zzIs6ev/aCy7JoZa02/XYXcM67b1XARM08HPVw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
       "requires": {
         "fault": "^1.0.2",
         "highlight.js": "~9.15.0"
@@ -10947,9 +10958,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+      "version": "0.5.25",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
+      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -10997,9 +11008,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.1.tgz",
-      "integrity": "sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
+      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11026,27 +11037,27 @@
       "dev": true
     },
     "needle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "requires": {
-        "debug": "^4.1.0",
+        "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
         "sax": "^1.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -11681,9 +11692,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12122,9 +12133,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12145,9 +12156,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12189,9 +12200,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12362,9 +12373,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -12787,9 +12798,9 @@
       }
     },
     "rehype-autolink-headings": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-2.0.4.tgz",
-      "integrity": "sha512-qbAbjCsn1rB+0mYD3ynq7KeP0JK2eK4WBKwh3tjmRUGWHQ07NbhWq2APlWEaR8dUK7cFZHSPE4lbnh3v26wKKA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-2.0.5.tgz",
+      "integrity": "sha512-gxG72uj8wV2WnjlanTu5qxV5xqLkI3H1q8HSWbof7fHa12FuT+X3fGj275KwxgXESi8hJvHtZiDUwcZ9rjcHRg==",
       "requires": {
         "extend": "^3.0.1",
         "hast-util-has-property": "^1.0.0",
@@ -12804,9 +12815,9 @@
       }
     },
     "rehype-highlight": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-2.2.1.tgz",
-      "integrity": "sha512-BuNg74O3lXoPHbkLjtTpd6bmnFy2jdcTeD1ZJ6SyWkI4RZkfRTKR0l3p/V7DQUHCYImMYOzeG0msbkgyaAsiJQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-2.2.2.tgz",
+      "integrity": "sha512-IjYQZycndUxM6GAIiyn/9B1CGXM+sp+DAsKzWrKio+2ysE3d9eRRexhsyYDwK1/dDNUhL+hic51bDzOnAVvMqg==",
       "requires": {
         "hast-util-to-string": "^1.0.0",
         "lowlight": "^1.10.0",
@@ -12871,9 +12882,9 @@
       }
     },
     "rehype-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-2.0.2.tgz",
-      "integrity": "sha512-CDCRfqx4qgfOSDG6t9KoyvrLejrICqhDJu0kNY2r5RhZLr2QHp9gG533nLzp6HLTVT0fSbZbdx8YvqLGpCBjPA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-2.0.3.tgz",
+      "integrity": "sha512-7hgS91klce+p/1CrgMjV/JKyVmEevTM3YMkFtxF29twydKBSYVcy2x44z74SgCnzANj8H8N0g0O8F1OH1/OXJA==",
       "requires": {
         "github-slugger": "^1.1.1",
         "hast-util-has-property": "^1.0.0",
@@ -12976,18 +12987,15 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "bundled": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "bundled": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "bundled": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -12996,8 +13004,7 @@
         },
         "strip-ansi": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+          "bundled": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -13030,8 +13037,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "bundled": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -14549,9 +14555,9 @@
       }
     },
     "to-vfile": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-5.0.2.tgz",
-      "integrity": "sha512-Gp2q0HCUR+4At6c6mvFKug75NP/8Cu5r7ONvEcJJPBGiDT4HeLBrRnPKJbOe84nHJqYhIah2y367Tr2+IUkwMA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-5.0.3.tgz",
+      "integrity": "sha512-z1Lfx60yAMDMmr+f426Y4yECsHdl8GVEAE+LymjRF5oOIZ7T4N20IxWNAxXLMRzP9jSSll38Z0fKVAhVLsdLOw==",
       "requires": {
         "is-buffer": "^2.0.0",
         "vfile": "^3.0.0"
@@ -14943,9 +14949,9 @@
       "integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg=="
     },
     "unist-util-inspect": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-4.1.3.tgz",
-      "integrity": "sha512-Fv9R88ZBbDp7mHN+wsbxS1r8VW3unyhZh/F18dcJRQsg0+g3DxNQnMS+AEG/uotB8Md+HMK/TfzSU5lUDWxkZg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-4.1.4.tgz",
+      "integrity": "sha512-7xxyvKiZ1SC9vL5qrMqKub1T31gRHfau4242F69CcaOrXt//5PmRVOmDZ36UAEgiT+tZWzmQmbNZn+mVtnR9HQ==",
       "requires": {
         "is-empty": "^1.0.0"
       }
@@ -15838,8 +15844,7 @@
       "dependencies": {
         "@pm2/agent-node": {
           "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/@pm2/agent-node/-/agent-node-1.1.8.tgz",
-          "integrity": "sha512-R5X6P+eZM9wVxix5HzJnoAo0F0JCnu9kJcPfscCKx+gVFw69VjmvXxTHGejYNMokrkIGQ+BIJQ2+/uGnLFvi3w==",
+          "bundled": true,
           "requires": {
             "debug": "^3.1.0",
             "eventemitter2": "^5.0.1",
@@ -15849,8 +15854,7 @@
         },
         "@pm2/io": {
           "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/@pm2/io/-/io-4.1.4.tgz",
-          "integrity": "sha512-CD5DZaOD2kvclks9MN3EHbohGeN0ZXc3H0607I4YL6LJHf8HaCtrB3na9USFToVbbKN3rNrvVSCTRkjNf22W1g==",
+          "bundled": true,
           "requires": {
             "@opencensus/core": "^0.0.9",
             "@opencensus/propagation-b3": "^0.0.8",
@@ -15868,41 +15872,35 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "bundled": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "bundled": true
             },
             "semver": {
               "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+              "bundled": true
             }
           }
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "bundled": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "bundled": true
         },
         "pm2": {
           "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/pm2/-/pm2-3.5.0.tgz",
-          "integrity": "sha512-/GlQ1cyy97Rw/4pLWXABRzyUkKSj6kmgPx6rygocfvXyLX44bv26RKy89wTOvaL51pb0JOS8v2FM6cRJf1pLrA==",
+          "bundled": true,
           "requires": {
             "@pm2/agent": "^0.5.22",
             "@pm2/io": "^4.1.2",
@@ -15939,16 +15937,14 @@
         },
         "remark-math": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-1.0.6.tgz",
-          "integrity": "sha512-I43wU/QOQpXvVFXKjA4FHp5xptK65+5F6yolm8+69/JV0EqSOB64wURUZ3JK50JtnTL8FvwLiH2PZ+fvsBxviA==",
+          "bundled": true,
           "requires": {
             "trim-trailing-lines": "^1.1.0"
           }
         },
         "ws": {
           "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "bundled": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }

--- a/packages/zmarkdown/README.md
+++ b/packages/zmarkdown/README.md
@@ -56,6 +56,10 @@ Only `metadata` is described in the **Response** sections below.
 
   Only parse inline Markdown elements (such as links and emphasis, unlike lists and fenced code blocks)
 
+* `opts.stats`, bool, default: `false`
+
+  Will compute and return statistics about markdown text
+ 
 ### Response
 
 * `metadata.disableToc`, bool
@@ -72,6 +76,12 @@ Only `metadata` is described in the **Response** sections below.
 * `metadata.languages`, string[]
 
   A list of unique languages used in GitHub Flavoured Markdown fences with a flag.
+
+* `metadata.stats` , object
+
+  stats about the parsed text:
+   - `signs`: number of chars, spaces uncluded
+   - ` words`: number of words
 
 ## `/latex` - Markdown to LaTeX
 

--- a/packages/zmarkdown/README.md
+++ b/packages/zmarkdown/README.md
@@ -80,7 +80,7 @@ Only `metadata` is described in the **Response** sections below.
 * `metadata.stats` , object
 
   stats about the parsed text:
-   - `signs`: number of chars, spaces uncluded
+   - `signs`: number of chars, spaces included
    - ` words`: number of words
 
 ## `/latex` - Markdown to LaTeX

--- a/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
@@ -3,22 +3,11 @@
 exports[`HTML endpoint accepts POSTed markdown 1`] = `"<h3 id=\\"foo\\">foo<a aria-hidden=\\"true\\" href=\\"#foo\\"><span class=\\"icon icon-link\\"></span></a></h3>"`;
 
 exports[`HTML endpoint produces statistics when configured 1`] = `
-"7 chars
-
-
-
-\\\\levelOneTitle{13 chars here}
-
-
-\\\\externalLink{13 chars here}{https.//github.com/zestedesavoir/zmarkdown}
-
-
-
-\\\\image{https.//github.com/zestedesavoir/zmarkdown}[13 chars here]
-
-
-\\\\image{https.//github.com/zestedesavoir/zmarkdown}[13 chars here]
-"
+"<p>7 chars</p>
+<h3 id=\\"13-chars-here\\">13 chars here<a aria-hidden=\\"true\\" href=\\"#13-chars-here\\"><span class=\\"icon icon-link\\"></span></a></h3>
+<p><a href=\\"https.//github.com/zestedesavoir/zmarkdown\\">13 chars here</a></p>
+<figure><img src=\\"https.//github.com/zestedesavoir/zmarkdown\\" alt=\\"13 chars here\\"><figcaption>13 chars here</figcaption></figure>
+<figure><img src=\\"https.//github.com/zestedesavoir/zmarkdown\\" alt=\\"no chars here\\"><figcaption>13 chars here</figcaption></figure>"
 `;
 
 exports[`LaTeX endpoint accepts POSTed markdown 1`] = `

--- a/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
@@ -2,6 +2,25 @@
 
 exports[`HTML endpoint accepts POSTed markdown 1`] = `"<h3 id=\\"foo\\">foo<a aria-hidden=\\"true\\" href=\\"#foo\\"><span class=\\"icon icon-link\\"></span></a></h3>"`;
 
+exports[`HTML endpoint produces statistics when configured 1`] = `
+"7 chars
+
+
+
+\\\\levelOneTitle{13 chars here}
+
+
+\\\\externalLink{13 chars here}{https.//github.com/zestedesavoir/zmarkdown}
+
+
+
+\\\\image{https.//github.com/zestedesavoir/zmarkdown}[13 chars here]
+
+
+\\\\image{https.//github.com/zestedesavoir/zmarkdown}[13 chars here]
+"
+`;
+
 exports[`LaTeX endpoint accepts POSTed markdown 1`] = `
 "\\\\levelOneTitle{foo}
 "

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -134,7 +134,7 @@ describe('HTML endpoint', () => {
     ![no chars here](https.//github.com/zestedesavoir/zmarkdown)
     Figure: 13 chars here
     `)
-    const response = await a.post(latex, {md: text, opts: {stats: true}})
+    const response = await a.post(html, {md: text, opts: {stats: true}})
     expect(response.status).toBe(200)
 
     const [string, metadata] = response.data

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -139,7 +139,7 @@ describe('HTML endpoint', () => {
 
     const [string, metadata] = response.data
     expect(string).toMatchSnapshot()
-    expect(metadata.stats.signs).toBe(59)
+    expect(metadata.stats.signs).toBe(64)
     expect(metadata.stats.words).toBe(14)
   })
 })

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -139,7 +139,7 @@ describe('HTML endpoint', () => {
 
     const [string, metadata] = response.data
     expect(string).toMatchSnapshot()
-    expect(metadata.stats.signs).toBe(64)
+    expect(metadata.stats.signs).toBe(61)
     expect(metadata.stats.words).toBe(14)
   })
 })

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -121,6 +121,27 @@ describe('HTML endpoint', () => {
     expect(rendered).not.toContain('view-box')
     expect(rendered).not.toContain('preserve-aspect-ratio')
   })
+
+  it('produces statistics when configured', async () => {
+    const text = dedent(`
+    7 chars
+    # 13 chars here
+    
+    [13 chars here](https.//github.com/zestedesavoir/zmarkdown)
+    
+    ![13 chars here](https.//github.com/zestedesavoir/zmarkdown)
+    
+    ![no chars here](https.//github.com/zestedesavoir/zmarkdown)
+    Figure: 13 chars here
+    `)
+    const response = await a.post(latex, {md: text, opts: {stats: true}})
+    expect(response.status).toBe(200)
+
+    const [string, metadata] = response.data
+    expect(string).toMatchSnapshot()
+    expect(metadata.stats.signs).toBe(59)
+    expect(metadata.stats.words).toBe(14)
+  })
 })
 
 describe('LaTeX endpoint', () => {

--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -127,7 +127,8 @@ const zmdParser = (config, extraRemarkPlugins = []) => {
       let signs = 0
       let words = 0
       visit(tree, 'text', (node) => {
-        signs += node.value.length
+        // +1 stands for EOL char
+        signs += node.value.length + 1
         words += node.value.match(/\w+/g).length
       })
       vfile.data.stats = {

--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -122,6 +122,21 @@ const zmdParser = (config, extraRemarkPlugins = []) => {
       }
     })
 
+  if (config.stats) {
+    mdProcessor.use(() => (tree, vfile) => {
+      let signs = 0
+      let words = 0
+      visit(tree, 'text', (node) => {
+        signs += node.value.length
+        words += node.value.match(/\w+/g).length
+      })
+      vfile.data.stats = {
+        signs: signs,
+        words: words,
+      }
+    })
+  }
+
   for (const record of extraRemarkPlugins) {
     mdProcessor.use(record.obj, record.option)
   }

--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -127,9 +127,11 @@ const zmdParser = (config, extraRemarkPlugins = []) => {
       let signs = 0
       let words = 0
       visit(tree, 'text', (node) => {
-        // +1 stands for EOL char
-        signs += node.value.length + 1
+        signs += node.value.length
         words += node.value.match(/\w+/g).length
+      })
+      visit(tree, 'paragraph', (node) => {
+        signs += 1
       })
       vfile.data.stats = {
         signs: signs,

--- a/packages/zmarkdown/server/handlers.js
+++ b/packages/zmarkdown/server/handlers.js
@@ -119,7 +119,7 @@ module.exports = function markdownHandlers (Raven) {
         remark.iframes['jsfiddle.net'].disabled = true
         remark.iframes['www.jsfiddle.net'].disabled = true
       }
-
+      remark.stats = opts.stats === true
       remark.imagesDownload.disabled = opts.disable_images_download === true
       if (remark.imagesDownload.disabled !== true) {
         if (opts.images_download_dir) {


### PR DESCRIPTION
# goal of this PR

On ZDS we have an estimated time of reading for all contents.

For now this indication is not reliable at all because it uses a bare `len(text)` to evaluate the size of content.
This is problematic because it includes mardown-syntax and URL related chars.

In this PR I evaluate the true number of chars by visiting text nodes.