### PR TITLE
Update regex to correctly match brackets

### DIFF
--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -1,7 +1,7 @@
 const spaceSeparated = require('space-separated-tokens')
 
 function escapeRegExp (str) {
-  return str.replace(/[-[]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+  return str.replace(/[-[\]{}()/*+?.\\^$|]/g, '\\$&')
 }
 
 const C_NEWLINE = '\n'

--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -1,7 +1,7 @@
 const spaceSeparated = require('space-separated-tokens')
 
 function escapeRegExp (str) {
-  return str.replace(new RegExp(`[-[\\]{}()*+?.\\\\^$|/]`, 'g'))
+  return str.replace(new RegExp(`[-[\\]{}()*+?.\\\\^$|/]`, 'g'), "\\$&")
 }
 
 const C_NEWLINE = '\n'

--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -1,7 +1,7 @@
 const spaceSeparated = require('space-separated-tokens')
 
 function escapeRegExp (str) {
-  return str.replace(new RegExp(`[-[\\]{}()*+?.\\\\^$|/]`, 'g'), "\\$&")
+  return str.replace(new RegExp(`[-[\\]{}()*+?.\\\\^$|/]`, 'g'), '\\$&')
 }
 
 const C_NEWLINE = '\n'

--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -1,7 +1,7 @@
 const spaceSeparated = require('space-separated-tokens')
 
 function escapeRegExp (str) {
-  return str.replace(/[-[\]{}()/*+?.\\^$|]/g, '\\$&')
+  return str.replace(new RegExp(`[-[\\]{}()*+?.\\\\^$|/]`, 'g'))
 }
 
 const C_NEWLINE = '\n'


### PR DESCRIPTION
Trying again.
Remove unnecessary escapes. Add necessary escape to correctly 
match brackets. Pattern was incorrectly matching `-` or `[`
followed by the literal string `/{}()*+?.\^$|]` only correctly
replacing the `-` or the `[` with a escape `\`.