### PR TITLE
remark-grid-tables: Ignore spaces at the right

### DIFF
--- a/packages/remark-grid-tables/__tests__/index.js
+++ b/packages/remark-grid-tables/__tests__/index.js
@@ -141,6 +141,28 @@ test('regression: should not crash when followed by "sth<space>"', () => {
   expect(contents).toBe(base)
 })
 
+test('regression: should ignore spaces at the right of the table', () => {
+  const {contents: base} = render(dedent`
+    +---+
+    | A |
+    +===+
+    | B |
+    +---+
+
+    `)
+
+  const {contents} = render(dedent`
+    +---+
+    | A |
+    +===+···
+    | B |·
+    +---+
+
+    `.replace(/·/g, ' '))
+
+  expect(contents).toBe(base)
+})
+
 test('regression: handles east asian ambiguous width', () => {
   const {contents: base} = render(dedent`
     +---+

--- a/packages/remark-grid-tables/dist/index.js
+++ b/packages/remark-grid-tables/dist/index.js
@@ -384,10 +384,12 @@ function extractTable(value, eat, tokenizer) {
   if (!possibleGridTable[i + 1]) return [null, null, null, null];
   var lineLength = stringWidth(possibleGridTable[i + 1]);
   var gridTable = [];
+  var realGridTable = [];
   var hasHeader = false;
 
   for (; i < possibleGridTable.length; i++) {
     var _line = possibleGridTable[i];
+    var realLine = markdownLines[i];
     var isMainLine = totalMainLineRegex.exec(_line); // line is in table
 
     if (isMainLine && stringWidth(_line) === lineLength) {
@@ -397,6 +399,7 @@ function extractTable(value, eat, tokenizer) {
       else if (_isHeaderLine && hasHeader) {
           break;
         }
+      realGridTable.push(realLine);
       gridTable.push(_line);
     } else {
       // this line is not in the grid table.
@@ -424,7 +427,7 @@ function extractTable(value, eat, tokenizer) {
     after.push(markdownLines[i]);
   }
 
-  return [before, gridTable, after, hasHeader];
+  return [before, gridTable, realGridTable, after, hasHeader];
 }
 
 function extractTableContent(lines, linesInfos, hasHeader) {
@@ -544,18 +547,19 @@ function gridTableTokenizer(eat, value, silent) {
   if (!keep) return;
 
   var _extractTable = extractTable(value, eat, this),
-      _extractTable2 = _slicedToArray(_extractTable, 4),
+      _extractTable2 = _slicedToArray(_extractTable, 5),
       before = _extractTable2[0],
       gridTable = _extractTable2[1],
-      after = _extractTable2[2],
-      hasHeader = _extractTable2[3];
+      realGridTable = _extractTable2[2],
+      after = _extractTable2[3],
+      hasHeader = _extractTable2[4];
 
   if (!gridTable || gridTable.length < 3) return;
   var now = eat.now();
   var linesInfos = computeColumnStartingPositions(gridTable);
   var tableContent = extractTableContent(gridTable, linesInfos, hasHeader);
   var tableElt = generateTable(tableContent, now, this);
-  var merged = merge(before, gridTable, after); // Because we can't add multiples blocs in one eat, I use a temp block
+  var merged = merge(before, realGridTable, after); // Because we can't add multiples blocs in one eat, I use a temp block
 
   var wrapperBlock = {
     type: 'element',

--- a/packages/remark-grid-tables/src/index.js
+++ b/packages/remark-grid-tables/src/index.js
@@ -295,9 +295,11 @@ function extractTable (value, eat, tokenizer) {
   if (!possibleGridTable[i + 1]) return [null, null, null, null]
   const lineLength = stringWidth(possibleGridTable[i + 1])
   const gridTable = []
+  const realGridTable = []
   let hasHeader = false
   for (; i < possibleGridTable.length; i++) {
     const line = possibleGridTable[i]
+    const realLine = markdownLines[i]
     const isMainLine = totalMainLineRegex.exec(line)
     // line is in table
     if (isMainLine && stringWidth(line) === lineLength) {
@@ -307,6 +309,7 @@ function extractTable (value, eat, tokenizer) {
       else if (isHeaderLine && hasHeader) {
         break
       }
+      realGridTable.push(realLine)
       gridTable.push(line)
     } else {
       // this line is not in the grid table.
@@ -333,7 +336,7 @@ function extractTable (value, eat, tokenizer) {
     after.push(markdownLines[i])
   }
 
-  return [before, gridTable, after, hasHeader]
+  return [before, gridTable, realGridTable, after, hasHeader]
 }
 
 function extractTableContent (lines, linesInfos, hasHeader) {
@@ -453,14 +456,14 @@ function gridTableTokenizer (eat, value, silent) {
   const keep = mainLineRegex.exec(value)
   if (!keep) return
 
-  const [before, gridTable, after, hasHeader] = extractTable(value, eat, this)
+  const [before, gridTable, realGridTable, after, hasHeader] = extractTable(value, eat, this)
   if (!gridTable || gridTable.length < 3) return
 
   const now = eat.now()
   const linesInfos = computeColumnStartingPositions(gridTable)
   const tableContent = extractTableContent(gridTable, linesInfos, hasHeader)
   const tableElt = generateTable(tableContent, now, this)
-  const merged = merge(before, gridTable, after)
+  const merged = merge(before, realGridTable, after)
 
   // Because we can't add multiples blocs in one eat, I use a temp block
   const wrapperBlock = {


### PR DESCRIPTION
Fix: #339
+1 test

The idea of the fix is simple. The problem was that to work with a valide grid, the plugin trim the end of every lines which implies problem when it comes to eat. Now it conserves a version with the spaces to "eat" and still use the valide trimed grid for everything else. 

Do not hesitate to propose another method. :D 

💖