### PR TITLE
Add IDL description for packages where it was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
 
 * [**rehype-footnotes-title**][rehype-footnotes-title]
 
-  TODO: README
+  This plugin adds a `title` attribute to the footnote links, mainly for accessibility purpose.
 
 * [**rehype-html-blocks**][rehype-html-blocks]
 
-  TODO: README
+  This plugin wraps (multi-line) raw HTML in `p`.
 
 * [**remark-align**][remark-align]
 
@@ -78,7 +78,7 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
 
 * [**remark-escape-escaped**][remark-escape-escaped]
 
-  TODO: README
+  This plugin escapes HTML entities from Markdown input.
 
 * [**remark-grid-tables**][remark-grid-tables]
 
@@ -90,7 +90,7 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
 
 * [**remark-heading-trailing-spaces**][remark-heading-trailing-spaces]
 
-  TODO: README
+  This plugin removes trailing spaces from Markdown headers.
 
 * [**remark-iframes**][remark-iframes]
 
@@ -102,7 +102,7 @@ This project uses [Jest][jest] for testing. It is recommended to install the Jes
 
 * [**remark-numbered-footnotes**][remark-numbered-footnotes]
 
-  TODO: README
+  This plugin changes how [mdast][mdast] footnotes are displayed by using sequential numbers as footnote references instead of user-specified strings.
 
 * [**remark-sub-super**][remark-sub-super]
 

--- a/packages/rehype-footnotes-title/README.md
+++ b/packages/rehype-footnotes-title/README.md
@@ -1,6 +1,5 @@
 This plugin adds a `title` attribute to the footnote links, mainly for accessibility purpose.
 
-
 ```diff
  <div class="footnotes">
    <hr>

--- a/packages/remark-align/README.md
+++ b/packages/remark-align/README.md
@@ -2,11 +2,51 @@
 
 This plugin parses custom Markdown syntax to center- or right-align elements.
 
-It adds three new node types to the [mdast][mdast] produced by [remark][remark]:
+## AST node (see [mdast][mdast] specification)
 
-* `LeftAligned`
-* `CenterAligned`
-* `RightAligned`
+It adds three new node types, described below, to the [mdast][mdast] produced by [remark][remark]:
+
+### `LeftAligned`
+
+```javascript
+interface LeftAligned <: Parent {
+  type: "leftAligned";
+  data: {
+    hName: "div";
+    hProperties: {
+      class: string;
+    }
+  }
+}
+```
+
+### `CenterAligned`
+
+```javascript
+interface CenterAligned <: Parent {
+  type: "centerAligned";
+  data: {
+    hName: "div";
+    hProperties: {
+      class: string;
+    }
+  }
+}
+```
+
+### `RightAligned`
+
+```javascript
+interface RightAligned <: Parent {
+  type: "rightAligned";
+  data: {
+    hName: "div";
+    hProperties: {
+      class: string;
+    }
+  }
+}
+```
 
 If you are using [rehype][rehype], the stringified HTML result will be `div`s with configurable CSS classes.
 

--- a/packages/remark-comments/README.md
+++ b/packages/remark-comments/README.md
@@ -12,6 +12,19 @@ Foo<--COMMENTS I am a comment COMMENTS-->bar
 
 Everything between `<--COMMENTS` and `COMMENTS-->` will be absent from the HTML output. Compiling to Markdown will preserve all comments.
 
+## AST node (see [mdast][mdast] specification)
+
+The plugin will product the following node and add it to the MDAST syntax tree:
+
+```javascript
+interface Comments <: Node {
+  type: "comments";
+  data: {
+    comment: string;
+  }
+}
+```
+
 ## Installation
 
 [npm][npm]:

--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -23,7 +23,7 @@ By default, the plugin will produce the following two nodes, where `whatnot` is 
 interface whatnotCustomBlock <: Parent {
   type: "whatnotCustomBlock";
   data: {
-    hName: string;
+    hName: "div" or "details";
     hProperties: {
       className: [string];
     }
@@ -35,7 +35,7 @@ interface whatnotCustomBlock <: Parent {
 interface whatnotCustomBlockBody <: Parent {
   type: "whatnotCustomBlockBody";
   data: {
-    hName: string;
+    hName: "div";
     hProperties: {
       className: [string];
     }
@@ -49,7 +49,7 @@ If your block has an heading, the following node will also be produced:
 interface whatnotCustomBlockHeading <: Parent {
   type: "whatnotCustomBlockHeading";
   data: {
-    hName: "div";
+    hName: "div" or "summary";
     hProperties: {
       className: [string];
     }

--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -15,6 +15,48 @@ Each custom block can specify CSS classes and whether users are allowed or requi
 
 Only inline Markdown will be parsed in titles.
 
+## AST nodes (see [mdast][mdast] specification)
+
+By default, the plugin will produce the following two nodes, where `whatnot` is the name of you block:
+
+```javascript
+interface whatnotCustomBlock <: Parent {
+  type: "whatnotCustomBlock";
+  data: {
+    hName: string;
+    hProperties: {
+      className: [string];
+    }
+  }
+}
+```
+
+```javascript
+interface whatnotCustomBlockBody <: Parent {
+  type: "whatnotCustomBlockBody";
+  data: {
+    hName: string;
+    hProperties: {
+      className: [string];
+    }
+  }
+}
+```
+
+If your block has an heading, the following node will also be produced:
+
+```javascript
+interface whatnotCustomBlockHeading <: Parent {
+  type: "whatnotCustomBlockHeading";
+  data: {
+    hName: "div";
+    hProperties: {
+      className: [string];
+    }
+  }
+}
+```
+
 ## Installation
 
 [npm][npm]:

--- a/packages/remark-custom-blocks/README.md
+++ b/packages/remark-custom-blocks/README.md
@@ -43,7 +43,7 @@ interface whatnotCustomBlockBody <: Parent {
 }
 ```
 
-If your block has an heading, the following node will also be produced:
+If your block has a heading, the following node will also be produced:
 
 ```javascript
 interface whatnotCustomBlockHeading <: Parent {

--- a/packages/remark-grid-tables/README.md
+++ b/packages/remark-grid-tables/README.md
@@ -27,7 +27,7 @@ A `gridTable` mdast node can contain the following mdast node types:
 interface TableHeader <: Parent {
   type: "tableHeader";
   data: {
-    hName: string;
+    hName: "thead" or "tbody";
   }
 }
 ```

--- a/packages/remark-grid-tables/README.md
+++ b/packages/remark-grid-tables/README.md
@@ -2,17 +2,63 @@
 
 This plugin parses custom Markdown syntax to describe tables. It was inspired by [this syntax](https://github.com/smartboyathome/Markdown-GridTables/blob/b4d16d5d254bed4336713d27eb8a37dc0e5f4273/mdx_grid_tables.py).
 
+## AST nodes
+
 It adds a new node type to the [mdast][mdast] produced by [remark][remark]: `gridTable`.
-
-A `gridTable` mdast node can contain the following mdast node types:
-
-* `tableHeader`
-* `tableRow`
-* `tableCell`
 
 If you are using [rehype][rehype], the stringified HTML result will be a `table`.
 
 It is up to you to have CSS rules producing the desired result for these `table`.
+
+```javascript
+interface GridTable <: Parent {
+  type: "gridTable";
+  data: {
+    hName: "table";
+  }
+}
+```
+
+A `gridTable` mdast node can contain the following mdast node types:
+
+### `tableHeader`
+
+```javascript
+interface TableHeader <: Parent {
+  type: "tableHeader";
+  data: {
+    hName: string;
+  }
+}
+```
+
+Where `hName` can be either `thead` or `tbody`.
+
+### `tableRow`
+
+```javascript
+interface TableRow <: Parent {
+  type: "tableRow";
+  data: {
+    hName: "tr";
+  }
+}
+```
+
+### `tableCell`
+
+```javascript
+interface TableCell <: Parent {
+  type: "tableCell";
+  data: {
+    hName: "td";
+    hProperties: {
+      colspan: number >= 1;
+      rowspan: number >= 1;
+    }
+  }
+}
+```
 
 ## Syntax
 

--- a/packages/remark-heading-trailing-spaces/README.md
+++ b/packages/remark-heading-trailing-spaces/README.md
@@ -1,4 +1,4 @@
-This package manages headers with trailing spaces.
+This plugin removes trailing spaces from Markdown headers.
 
 Examples, here `·` represents a space ` `
 

--- a/packages/remark-numbered-footnotes/README.md
+++ b/packages/remark-numbered-footnotes/README.md
@@ -1,1 +1,1 @@
-This plugin changes how mdast footnotes are displayed by using sequential numbers as footnote references instead of user-specified strings.
+This plugin changes how [mdast][mdast] footnotes are displayed by using sequential numbers as footnote references instead of user-specified strings.


### PR DESCRIPTION
Solves issue #126 ; IDL description was added for

- remark-align;
- remark-comments;
- remark-custom-blocks;
- remark-grid-tables.

It has already been done by some previous PRs for:

- remark-abbr and
- remark-emoticons.

I also added descriptions in the main README for packages where it was missing.

Two questions for me:

- is there a way to use something like "div OR details" instead of "string" for rehype's `hName`?
- maybe we could do something better for my `whatnotCustomBlock`?

Poke @vhf for a review.