### PR TITLE
rebber-plugins: Protect custom block titles

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -194,14 +194,14 @@ baz
 \\\\end{Error}
 
 
-\\\\begin{Error}[a bad error]
+\\\\begin{Error}[{{a bad error}}]
 \\\\textbf{error}
 foo bar \\\\\\\\
 baz
 \\\\end{Error}
 
 
-\\\\begin{Neutre}[\\\\textbf{title}]
+\\\\begin{Neutre}[{{\\\\textbf{title}}}]
 foo
 \\\\end{Neutre}"
 `;

--- a/packages/rebber-plugins/dist/type/customBlocks.js
+++ b/packages/rebber-plugins/dist/type/customBlocks.js
@@ -8,7 +8,7 @@ var all = require('rebber/dist/all');
 module.exports = customBlock;
 var defaultMacros = {
   defaultBlock: function defaultBlock(environmentName, blockTitle, blockContent) {
-    return "\\begin{".concat(environmentName, "}").concat(blockTitle ? "[".concat(blockTitle, "]") : '') + "\n".concat(blockContent) + "\n\\end{".concat(environmentName, "}\n");
+    return "\\begin{".concat(environmentName, "}").concat(blockTitle ? "[{{".concat(blockTitle, "}}]") : '') + "\n".concat(blockContent) + "\n\\end{".concat(environmentName, "}\n");
   }
 };
 

--- a/packages/rebber-plugins/src/type/customBlocks.js
+++ b/packages/rebber-plugins/src/type/customBlocks.js
@@ -6,7 +6,7 @@ module.exports = customBlock
 
 const defaultMacros = {
   defaultBlock: (environmentName, blockTitle, blockContent) => {
-    return `\\begin{${environmentName}}${blockTitle ? `[${blockTitle}]` : ''}` +
+    return `\\begin{${environmentName}}${blockTitle ? `[{{${blockTitle}}}]` : ''}` +
       `\n${blockContent}` +
       `\n\\end{${environmentName}}\n`
   },

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -4083,12 +4083,12 @@ with content after
 
 
 
-\\\\begin{Error}[a \\\\textbf{title}]
+\\\\begin{Error}[{{a \\\\textbf{title}}}]
 content
 \\\\end{Error}
 
 
-\\\\begin{Neutral}[a \\\\textbf{title}]
+\\\\begin{Neutral}[{{a \\\\textbf{title}}}]
 content
 \\\\end{Neutral}"
 `;


### PR DESCRIPTION
Simply adds `{{` and `}}` on custom block titles for LaTeX rendering in order to prevent problems during the PDF generation. See issue #349 for details of the solution. Tests already handle this, so snapshots were only updated.

~~Please wait for confirmation on the issue before merging.~~
It works, no problems whatsoever.