### PR TITLE
Allow to use default black image when server error on image downloading

### DIFF
--- a/packages/remark-images-download/README.md
+++ b/packages/remark-images-download/README.md
@@ -33,6 +33,12 @@ unified()
   .use(remarkImagesDownload, {
     disabled: true,
     downloadDestination: './img/',
+    defaultImagePath: 'black.png',
+    defaultOn: {
+      statusCode: true,
+      mimeType: false,
+      fileTooBig: false,
+    },
     maxlength: 1000000,
     dirSizeLimit: 10000000,
     localUrlToLocalPath: (localUrl) => localPath
@@ -52,6 +58,27 @@ All options are optional.
 - `downloadDestination`: string, default: `/tmp`
 
   Parent destination folder for downloads.
+
+- `defaultImagePath`: string or boolean, default: `false`
+
+  Image path to fallback to for images that couldn't be found.
+  Set to `false` or keep default value to disable.
+
+- `defaultOn`: object, with properties,
+
+  Cases when the default image should be used.
+
+  - `statusCode`: boolean, default `false`
+
+    The status code is different than 200.
+
+  - `mimeType`: boolean, default `false`
+
+    The MIME type does not match an image.
+
+  - `fileTooBig`: boolean, default `false`
+
+    The file size exceed the `maxFileSize` limit.
 
 - `maxFileLength`: number, default: `1000000`
 

--- a/packages/remark-images-download/__tests__/index.js
+++ b/packages/remark-images-download/__tests__/index.js
@@ -128,6 +128,24 @@ describe('mock server tests', () => {
     )
   })
 
+  test('default big images', () => {
+    const defaultImagePath = 'default.png'
+    const file = `![](http://localhost:27273/ok.png)`
+    const html = `<p><img src="${downloadDestination}/${defaultImagePath}"></p>`
+
+    const render = renderFactory({
+      maxFileSize: 400,
+      defaultImagePath,
+      defaultOn: {
+        fileTooBig: true,
+      },
+    })
+
+    return render(file).then(vfile => {
+      expect(vfile.contents).toBe(html)
+    })
+  })
+
   test('reports bad SVG', () => {
     const file = `![](http://localhost:27273/bad.svg)`
     const html = `<p><img src="http://localhost:27273/bad.svg"></p>`
@@ -151,6 +169,23 @@ describe('mock server tests', () => {
     return render(file).then(vfile => {
       expect(firstMsg(vfile)).toBe(
         'Content-Type of http://localhost:27273/wrong-mime.txt is not an image/ type')
+      expect(vfile.contents).toBe(html)
+    })
+  })
+
+  test('default wrong mime', () => {
+    const defaultImagePath = 'default.png'
+    const file = `![](http://localhost:27273/wrong-mime.txt)`
+    const html = `<p><img src="${downloadDestination}/${defaultImagePath}"></p>`
+
+    const render = renderFactory({
+      defaultImagePath,
+      defaultOn: {
+        mimeType: true,
+      },
+    })
+
+    return render(file).then(vfile => {
       expect(vfile.contents).toBe(html)
     })
   })
@@ -430,6 +465,23 @@ describe('mock server tests', () => {
     return render(file).then(vfile => {
       expect(firstMsg(vfile)).toBe(
         'Received HTTP404 for: http://localhost:27273/404/notfound')
+      expect(vfile.contents).toBe(html)
+    })
+  })
+
+  test('default bad status code', () => {
+    const defaultImagePath = 'default.png'
+    const file = `![](http://localhost:27273/noimage.png)`
+    const html = `<p><img src="${downloadDestination}/${defaultImagePath}"></p>`
+
+    const render = renderFactory({
+      defaultImagePath,
+      defaultOn: {
+        statusCode: true,
+      },
+    })
+
+    return render(file).then(vfile => {
       expect(vfile.contents).toBe(html)
     })
   })

--- a/packages/zmarkdown/README.md
+++ b/packages/zmarkdown/README.md
@@ -30,6 +30,7 @@ Only `metadata` is described in the **Response** sections below.
 ### Request
 
 * `opts.images_download_dir`: see `/latex`
+* `opts.images_download_default`: see `/latex`
 * `opts.local_url_to_local_path`: see `/latex`
 
 ### Response
@@ -94,6 +95,10 @@ Only `metadata` is described in the **Response** sections below.
 * `opts.images_download_dir`, string
 
   Where to download the images to.
+
+* `opts.images_download_default`, string, default: `black.png`
+
+  Path where to default where the distant image is not found.
 
 * `opts.local_url_to_local_path`, \[from: string, to: string\], default: `<none>`
 

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -210,6 +210,32 @@ describe('LaTeX endpoint', () => {
     const [, dir, file, ext] = rendered.match(regex)
     return expect(rm(`${destination}/${dir}`, `${file}.${ext}`)).resolves.toBe('ok')
   })
+
+  it('properly defaults image', async () => {
+    const destination = process.env.DEST || `${__dirname}/../public/`
+    const response = await a.post(latex, {
+      md: `![](${u('/static/noimage.png')})`,
+      opts: {inline: true, images_download_dir: destination},
+    })
+
+    const rendered = response.data[0]
+    expect(rendered).toContain('black.png')
+  })
+
+  it('properly defaults image with custom path', async () => {
+    const destination = process.env.DEST || `${__dirname}/../public/`
+    const response = await a.post(latex, {
+      md: `![](${u('/static/noimage.png')})`,
+      opts: {
+        inline: true,
+        images_download_dir: destination,
+        images_download_default: 'default.png',
+      },
+    })
+
+    const rendered = response.data[0]
+    expect(rendered).toContain('default.png')
+  })
 })
 
 describe('Texfile endpoint', () => {

--- a/packages/zmarkdown/config/remark.js
+++ b/packages/zmarkdown/config/remark.js
@@ -315,6 +315,12 @@ const remarkConfig = {
 
   imagesDownload: {
     disabled: true,
+    defaultImagePath: 'black.png',
+    defaultOn: {
+      statusCode: true,
+      mimeType: false,
+      fileTooBig: false,
+    },
     downloadDestination: './img/',
     maxlength: 1000000,
     dirSizeLimit: 10000000,

--- a/packages/zmarkdown/server/handlers.js
+++ b/packages/zmarkdown/server/handlers.js
@@ -134,6 +134,9 @@ module.exports = function markdownHandlers (Raven) {
         if (opts.images_download_timeout) {
           remark.imagesDownload.httpRequestTimeout = opts.images_download_timeout
         }
+        if (typeof opts.images_download_default === 'string') {
+          remark.imagesDownload.defaultImagePath = opts.images_download_default
+        }
       }
 
       if (opts.inline === true) {


### PR DESCRIPTION
Solves issue #294 in two parts:

## `remark-images-download`: add an optional parameter

A new option was added to the package to allow replacing the default image path with a custom "error image" on three different cases:

- status code matches an error (!= 200);
- MIME type is incorrect;
- file exceed max size.

The first thing to do is to enable the option - please note that **no breaking changes** were made, the package still works as it did before, a new option was simply added - using `defaultImagePath` which corresponds to the path of the image to fallback to. Once this is done, simply tell the plugin when it should fallback using `defaultOn`, specified in the README.

Technically, the fallback is done by adding a boolean to the error returned by the Promise (on `reject`), called `error.replaceWithDefault`, and that will allow us to add more cases for the fallback later if needed. When this boolean is matched to `true`, the AST is mutated by changing the image URL to the concatenated default path.

Three tests were also added for the three use cases independently.

## `zmarkdown` add an option to the LaTeX endpoint

On ZMarkdown side, the change **is possibly breaking**, as it changes the default configuration and could change the HTML rendering if these defaults are used. A new option, `images_download_default` is available for endpoints that allow images download.

By default, fallback is done to `black.png`, but can be changed using EPUB or LaTeX endpoint option, as @artragis requested. Of the three cases mentionned above, only one is used here right now: erroneous status code, because we only need this case for Zeste de Savoir; if another case is to be used in the future, a simple change to `remark.js` configuration file is needed.

Please review @vhf and tell me if it looks good.