### PR TITLE
[remark-disable-tokenizers] Add caveat about autoLinking to README

### DIFF
--- a/packages/remark-disable-tokenizers/README.md
+++ b/packages/remark-disable-tokenizers/README.md
@@ -69,6 +69,20 @@ unified()
   .use(stringify)
 ```
 
+## Caveats
+
+* `autoLink` is not working correctly -- in order to disable auto-linking, you have to pass `url` to the array of disabled inline tokenizers.
+
+```javascript
+unified()
+  .use(remarkParse)
+  .use(remarkDisableTokenizers, {
+    inline: ['url']
+  })
+  .use(remark2rehype)
+  .use(stringify)
+```
+
 ## License
 
 [MIT][license] © [Zeste de Savoir][zds]


### PR DESCRIPTION
As per #358, autoLink currently does nothing for some reason. Until the core issue is found and fixed, others trying to disable autoLinking might find it useful to know they should disable the  `url` tokenizer instead.