### PR TITLE
fix: update labels to use footnote numbers as well as identifiers

### DIFF
--- a/packages/remark-numbered-footnotes/src/index.js
+++ b/packages/remark-numbered-footnotes/src/index.js
@@ -34,8 +34,8 @@ function createIds (footnotes) {
     if (!footnotes.hasOwnProperty(identifier)) {
       footnotes[identifier] = Object.keys(footnotes).length + 1
     }
-    node.identifier = footnotes[identifier]
-    node.label = footnotes[identifier]
+    node.identifier = String(footnotes[identifier])
+    node.label = String(footnotes[identifier])
   }
 }
 
@@ -46,8 +46,8 @@ function replaceIds (footnotes) {
     if (!footnotes.hasOwnProperty(identifier)) {
       footnotes[identifier] = Object.keys(footnotes).length + 1
     }
-    node.identifier = footnotes[identifier]
-    node.label = footnotes[identifier]
+    node.identifier = String(footnotes[identifier])
+    node.label = String(footnotes[identifier])
   }
 }
 

--- a/packages/remark-numbered-footnotes/src/index.js
+++ b/packages/remark-numbered-footnotes/src/index.js
@@ -35,6 +35,7 @@ function createIds (footnotes) {
       footnotes[identifier] = Object.keys(footnotes).length + 1
     }
     node.identifier = footnotes[identifier]
+    node.label = footnotes[identifier]
   }
 }
 
@@ -46,6 +47,7 @@ function replaceIds (footnotes) {
       footnotes[identifier] = Object.keys(footnotes).length + 1
     }
     node.identifier = footnotes[identifier]
+    node.label = footnotes[identifier]
   }
 }
 


### PR DESCRIPTION
As of https://github.com/syntax-tree/mdast-util-to-hast/pull/31, the footnote label is used for footnotes instead of its identifier. This change brings back numbered footnotes correctly.

This was identified in this issue: https://github.com/gatsbyjs/gatsby/issues/16578

Once this is merged, we're able to fix the affected Gatsby plugin: https://github.com/jlengstorf/gatsby-remark-numbered-footnotes/issues/9

fixes #361 