### PR TITLE
Solves #364

### DIFF
--- a/packages/rebber-plugins/dist/type/emoticon.js
+++ b/packages/rebber-plugins/dist/type/emoticon.js
@@ -10,6 +10,6 @@ module.exports = emoticon;
 
 function emoticon(ctx, node) {
   var code = node.value;
-  if (!ctx.emoticons || !has(ctx.emoticons, code)) return;
-  return "\\smiley{".concat(ctx.emoticons[code], "}");
+  if (!ctx.emoticons.emoticons || !has(ctx.emoticons.emoticons, code)) return;
+  return "\\smiley{".concat(ctx.emoticons.emoticons[code], "}");
 }

--- a/packages/rebber-plugins/src/type/emoticon.js
+++ b/packages/rebber-plugins/src/type/emoticon.js
@@ -7,7 +7,7 @@ module.exports = emoticon
 /* Stringify an emoticon `node`. */
 function emoticon (ctx, node) {
   const code = node.value
-  if (!ctx.emoticons || !has(ctx.emoticons, code)) return
+  if (!ctx.emoticons.emoticons || !has(ctx.emoticons.emoticons, code)) return
 
-  return `\\smiley{${ctx.emoticons[code]}}`
+  return `\\smiley{${ctx.emoticons.emoticons[code]}}`
 }


### PR DESCRIPTION
It seems that the `emoticons` object needed was moved into `emoticons.emoticons` when `class` was added to `rehype-emoticons`.

#364 