### PR TITLE
rebber: fix stringification by replicating mdast-util-to-hast

### DIFF
--- a/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
+++ b/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
@@ -148,6 +148,7 @@ Auto-links should not occur here: \\\\texttt{<http://example.com/>}
 
 \\\\begin{CodeBlock}{text}
 or here: <http://example.com/>
+
 \\\\end{CodeBlock}"
 `;
 
@@ -428,6 +429,7 @@ Bang: \\\\!
 Plus: \\\\+
 
 Minus: \\\\-
+
 \\\\end{CodeBlock}
 
 
@@ -440,6 +442,7 @@ Minus: \\\\-
 Pipe: \\\\|
 
 Tilde: \\\\~
+
 \\\\end{CodeBlock}
 
 
@@ -479,6 +482,7 @@ Caret: \\\\^
 
 New line: \\\\
 only works in paragraphs.
+
 \\\\end{CodeBlock}
 
 
@@ -691,6 +695,7 @@ between them.
 
 \\\\begin{CodeBlock}{text}
 1.   Second sublist.
+
 \\\\end{CodeBlock}
 
 
@@ -707,6 +712,7 @@ And for lists followed by indented code blocks:
 
 \\\\begin{CodeBlock}{text}
 And this is code();
+
 \\\\end{CodeBlock}"
 `;
 
@@ -722,6 +728,7 @@ exports[`rebber: remark specs blockquote-lazy-code: blockquote-lazy-code 1`] = `
 \\\\begin{CodeBlock}{text}
 foo
 bar
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -730,6 +737,7 @@ exports[`rebber: remark specs blockquote-lazy-fence: blockquote-lazy-fence 1`] =
 "\\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 aNormalCodeBlockInABlockqoute();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -742,6 +750,7 @@ A paragraph.
 \\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 thisIsAlsoSomeCodeInABlockquote();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -754,6 +763,7 @@ A paragraph.
 \\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 aNonTerminatedCodeBlockInABlockquote();
+
 \\\\end{CodeBlock}
 
 aNewCodeBlockFollowingTheBlockQuote();
@@ -774,6 +784,7 @@ Something in a blockquote.
 
 \\\\begin{CodeBlock}{text}
 aNewCodeBlock();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -834,6 +845,7 @@ Example:
 sub status {
     print \\"working\\";
 }
+
 \\\\end{CodeBlock}
 
 Or:
@@ -842,6 +854,7 @@ Or:
 sub status {
     return \\"working\\";
 }
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -898,6 +911,7 @@ exports[`rebber: remark specs code-block: code-block 1`] = `
 
 \\\\begin{CodeBlock}{javascript}
 alert('Hello World!');
+
 \\\\end{CodeBlock}"
 `;
 
@@ -912,6 +926,7 @@ the code is exdented by up to that amount of spaces.
     This is a code block...
         
     ...which is not exdented.
+
 \\\\end{CodeBlock}
 
 
@@ -924,6 +939,7 @@ But...
   This one...
       
   ...is.
+
 \\\\end{CodeBlock}
 
 
@@ -936,6 +952,7 @@ And...
 So is this...
       
   ...one.
+
 \\\\end{CodeBlock}"
 `;
 
@@ -953,6 +970,7 @@ Note that this bug does not occur on indented code-blocks.
 \`\`\`bar
 baz
 \`\`\`
+
 \\\\end{CodeBlock}
 
 
@@ -965,6 +983,7 @@ Even with a different fence marker:
 ~~~bar
 baz
 ~~~
+
 \\\\end{CodeBlock}
 
 
@@ -977,6 +996,7 @@ And reversed:
 ~~~bar
 baz
 ~~~
+
 \\\\end{CodeBlock}
 
 
@@ -985,6 +1005,7 @@ baz
 \`\`\`bar
 baz
 \`\`\`
+
 \\\\end{CodeBlock}"
 `;
 
@@ -999,6 +1020,7 @@ Regular text.
 
 \\\\begin{CodeBlock}{text}
 code block indented by spaces
+
 \\\\end{CodeBlock}
 
 
@@ -1010,6 +1032,7 @@ Regular text.
 \\\\begin{CodeBlock}{text}
 the lines in this block  
 all contain trailing spaces  
+
 \\\\end{CodeBlock}
 
 
@@ -1020,6 +1043,7 @@ Regular Text.
 
 \\\\begin{CodeBlock}{text}
 code block on the last line
+
 \\\\end{CodeBlock}"
 `;
 
@@ -1052,8 +1076,7 @@ And here, \\\\texttt{\`\`}.
 
 
 
-So is this \\\\texttt{foo   bar
-  baz}.
+So is this \\\\texttt{foo bar baz}.
 
 
 
@@ -1259,6 +1282,7 @@ Entities even work in the language flag of fenced code blocks:
 
 \\\\begin{CodeBlock}{some—language}
 alert('Hello');
+
 \\\\end{CodeBlock}
 
 
@@ -1278,6 +1302,7 @@ code blocks:
 
 \\\\begin{CodeBlock}{text}
 C&Ouml;DE block.
+
 \\\\end{CodeBlock}"
 `;
 
@@ -1289,6 +1314,7 @@ Entities even work in the language flag of fenced code blocks:
 
 \\\\begin{CodeBlock}{some©language}
 alert('Hello');
+
 \\\\end{CodeBlock}
 
 And in an auto-link: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com}
@@ -1317,7 +1343,7 @@ Or in \\\\includegraphics{undefined}
 pl©ce\\"
 
 [
-  1
+1
 ]: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com} \\"in some
 pl©ce\\"
 \\\\end{Quotation}
@@ -1334,6 +1360,7 @@ code blocks:
 
 \\\\begin{CodeBlock}{text}
 C&OumlDE block.
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -1344,24 +1371,28 @@ exports[`rebber: remark specs fenced-code: fenced-code 1`] = `
 "\\\\begin{CodeBlock}{js}
 var a = 'hello';
 console.log(a + ' world');
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{bash}
 echo \\"hello, \${WORLD}\\"
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{longfence}
 Q: What do you call a tall person who sells stolen goods?
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{ManyTildes}
 A longfence!
+
 \\\\end{CodeBlock}"
 `;
 
@@ -1409,24 +1440,28 @@ exports[`rebber: remark specs fenced-code-trailing-characters: fenced-code-trail
 "\\\\begin{CodeBlock}{js}
 foo();
 \`\`\`bash
+
 \\\\end{CodeBlock}"
 `;
 
 exports[`rebber: remark specs fenced-code-trailing-characters-2: fenced-code-trailing-characters-2 1`] = `
 "\\\\begin{CodeBlock}{text}
 \`\`\` aaa
+
 \\\\end{CodeBlock}"
 `;
 
 exports[`rebber: remark specs fenced-code-white-space-after-flag: fenced-code-white-space-after-flag 1`] = `
 "\\\\begin{CodeBlock}{js}
 foo();
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{bash}
 echo \\"hello, \${WORLD}\\"
+
 \\\\end{CodeBlock}"
 `;
 
@@ -1744,6 +1779,7 @@ exports[`rebber: remark specs horizontal-rules: horizontal-rules 1`] = `
 
 \\\\begin{CodeBlock}{text}
 ---
+
 \\\\end{CodeBlock}
 
 
@@ -1766,6 +1802,7 @@ exports[`rebber: remark specs horizontal-rules: horizontal-rules 1`] = `
 
 \\\\begin{CodeBlock}{text}
 - - -
+
 \\\\end{CodeBlock}
 
 
@@ -1792,6 +1829,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -1814,6 +1852,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 * * *
+
 \\\\end{CodeBlock}
 
 
@@ -1840,6 +1879,7 @@ Underscores:
 
 \\\\begin{CodeBlock}{text}
 ___
+
 \\\\end{CodeBlock}
 
 
@@ -1862,6 +1902,7 @@ ___
 
 \\\\begin{CodeBlock}{text}
 _ _ _
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2116,8 +2157,9 @@ This should be a code block, though:
 
 \\\\begin{CodeBlock}{text}
 <div>
-	foo
+    foo
 </div>
+
 \\\\end{CodeBlock}
 
 
@@ -2128,6 +2170,7 @@ As should this:
 
 \\\\begin{CodeBlock}{text}
 <div>foo</div>
+
 \\\\end{CodeBlock}
 
 
@@ -2165,6 +2208,7 @@ Code block:
 
 \\\\begin{CodeBlock}{text}
 <!-- Comment -->
+
 \\\\end{CodeBlock}
 
 
@@ -2181,6 +2225,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 <hr>
+
 \\\\end{CodeBlock}
 
 
@@ -2551,6 +2596,7 @@ Indented [four] times.
 
 \\\\begin{CodeBlock}{text}
 [four]: /url
+
 \\\\end{CodeBlock}
 
 
@@ -2620,7 +2666,7 @@ breaks\\\\ref{link breaks} across lines.
 
 
 
-Here's another where the link 
+Here's another where the link
 breaks\\\\ref{link breaks} across lines, but with a line-ending space.
 
 
@@ -2640,7 +2686,7 @@ break\\\\ref{line break}.
 
 
 
-This one has a line 
+This one has a line
 break\\\\ref{line break} with a line-ending space.
 
 
@@ -3372,6 +3418,7 @@ exports[`rebber: remark specs list-and-code: list-and-code 1`] = `
 
 \\\\begin{CodeBlock}{text}
 This is code
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3392,6 +3439,7 @@ exports[`rebber: remark specs list-continuation: list-continuation 1`] = `
 
 \\\\begin{CodeBlock}{js}
 code();
+
 \\\\end{CodeBlock}
 
 
@@ -3439,6 +3487,7 @@ World 4a.
 World 4b.
 \\\\item \\\\begin{CodeBlock}{text}
 Hello 5a
+
 \\\\end{CodeBlock}
 
 World 5a.
@@ -3446,6 +3495,7 @@ World 5a.
 Hello 5b
 
 World 5b.
+
 \\\\end{CodeBlock}
 \\\\end{itemize}"
 `;
@@ -3575,6 +3625,7 @@ exports[`rebber: remark specs lists-with-code-and-rules: lists-with-code-and-rul
 \\\\begin{CodeBlock}{text}
 line 1
 line 2
+
 \\\\end{CodeBlock}
 \\\\item foo:
 
@@ -3583,6 +3634,7 @@ line 2
 
 \\\\begin{CodeBlock}{erb}
 some code here
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -3593,6 +3645,7 @@ bar
 ---
 foo
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -3602,6 +3655,7 @@ foo
 foo
 ---
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -3609,6 +3663,7 @@ bar
 foo
 ---
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo
 \\\\end{enumerate}
@@ -3717,8 +3772,8 @@ markdown.js doesnt acknowledge arbitrary html blocks =/</aside>
 Hi, this is a list item.
 \\\\item New List Item 2
 Another item
-    Code goes here.
-    Lots of it...
+Code goes here.
+Lots of it...
 \\\\item New List Item 3
 The last item
 \\\\end{itemize}
@@ -3774,6 +3829,7 @@ And an image with an empty alt attribute \\\\includegraphics{src}.
 \\\\begin{CodeBlock}{text}
 Code goes here.
 Lots of it...
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3866,6 +3922,7 @@ dog's back.
 > This is the second paragraph in the blockquote.
 >
 > ## This is an H2 in a blockquote
+
 \\\\end{CodeBlock}
 
 
@@ -3895,6 +3952,7 @@ dog's back.</p>
     
     <h2>This is an H2 in a blockquote</h2>
 </blockquote>
+
 \\\\end{CodeBlock}
 
 
@@ -3916,6 +3974,7 @@ Some of these words _are emphasized also_.
 
 Use two asterisks for **strong emphasis**.
 Or, if you prefer, __use two underscores instead__.
+
 \\\\end{CodeBlock}
 
 
@@ -3930,6 +3989,7 @@ Some of these words <em>are emphasized also</em>.</p>
 
 <p>Use two asterisks for <strong>strong emphasis</strong>.
 Or, if you prefer, <strong>use two underscores instead</strong>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -3947,6 +4007,7 @@ interchangable; this:
 *   Candy.
 *   Gum.
 *   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -3959,6 +4020,7 @@ this:
 +   Candy.
 +   Gum.
 +   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -3971,6 +4033,7 @@ and this:
 -   Candy.
 -   Gum.
 -   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -3985,6 +4048,7 @@ all produce the same output:
 <li>Gum.</li>
 <li>Booze.</li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -3998,6 +4062,7 @@ list markers:
 1.  Red
 2.  Green
 3.  Blue
+
 \\\\end{CodeBlock}
 
 
@@ -4012,6 +4077,7 @@ Output:
 <li>Green</li>
 <li>Blue</li>
 </ol>
+
 \\\\end{CodeBlock}
 
 
@@ -4028,6 +4094,7 @@ the paragraphs by 4 spaces or 1 tab:
     With multiple paragraphs.
 
 *   Another item in the list.
+
 \\\\end{CodeBlock}
 
 
@@ -4042,6 +4109,7 @@ Output:
 <p>With multiple paragraphs.</p></li>
 <li><p>Another item in the list.</p></li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -4062,6 +4130,7 @@ For example:
 
 \\\\begin{CodeBlock}{text}
 This is an [example link](http://example.com/).
+
 \\\\end{CodeBlock}
 
 
@@ -4073,6 +4142,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>This is an <a href=\\"http://example.com/\\">
 example link</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -4083,6 +4153,7 @@ Optionally, you may include a title attribute in the parentheses:
 
 \\\\begin{CodeBlock}{text}
 This is an [example link](http://example.com/ \\"With a Title\\").
+
 \\\\end{CodeBlock}
 
 
@@ -4094,6 +4165,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>This is an <a href=\\"http://example.com/\\" title=\\"With a Title\\">
 example link</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -4110,6 +4182,7 @@ I get 10 times more traffic from [Google][1] than from
 [1]: http://google.com/        \\"Google\\"
 [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
 [3]: http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -4123,6 +4196,7 @@ Output:
 title=\\"Google\\">Google</a> than from <a href=\\"http://search.yahoo.com/\\"
 title=\\"Yahoo Search\\">Yahoo</a> or <a href=\\"http://search.msn.com/\\"
 title=\\"MSN Search\\">MSN</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -4137,6 +4211,7 @@ I start my morning with a cup of coffee and
 [The New York Times][NY Times].
 
 [ny times]: http://www.nytimes.com/
+
 \\\\end{CodeBlock}
 
 
@@ -4148,6 +4223,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>I start my morning with a cup of coffee and
 <a href=\\"http://www.nytimes.com/\\">The New York Times</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -4165,6 +4241,7 @@ Inline (titles are optional):
 
 \\\\begin{CodeBlock}{text}
 ![alt text](/path/to/img.jpg \\"Title\\")
+
 \\\\end{CodeBlock}
 
 
@@ -4177,6 +4254,7 @@ Reference-style:
 ![alt text][id]
 
 [id]: /path/to/img.jpg \\"Title\\"
+
 \\\\end{CodeBlock}
 
 
@@ -4187,6 +4265,7 @@ Both of the above examples produce the same output:
 
 \\\\begin{CodeBlock}{text}
 <img src=\\"/path/to/img.jpg\\" alt=\\"alt text\\" title=\\"Title\\" />
+
 \\\\end{CodeBlock}
 
 
@@ -4206,6 +4285,7 @@ I strongly recommend against using any \`<blink>\` tags.
 
 I wish SmartyPants used named entities like \`&mdash;\`
 instead of decimal-encoded entites like \`&#8212;\`.
+
 \\\\end{CodeBlock}
 
 
@@ -4221,6 +4301,7 @@ Output:
 <p>I wish SmartyPants used named entities like
 <code>&amp;mdash;</code> instead of decimal-encoded
 entites like <code>&amp;#8212;</code>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -4242,6 +4323,7 @@ you've got to put paragraph tags in your blockquotes:
     <blockquote>
         <p>For example.</p>
     </blockquote>
+
 \\\\end{CodeBlock}
 
 
@@ -4258,6 +4340,7 @@ you've got to put paragraph tags in your blockquotes:</p>
     &lt;p&gt;For example.&lt;/p&gt;
 &lt;/blockquote&gt;
 </code></pre>
+
 \\\\end{CodeBlock}"
 `;
 
@@ -4405,6 +4488,7 @@ This is a regular paragraph.
 </table>
 
 This is another regular paragraph.
+
 \\\\end{CodeBlock}
 
 
@@ -4446,6 +4530,7 @@ escape ampersands within URLs. Thus, if you want to link to:
 
 \\\\begin{CodeBlock}{text}
 http://images.google.com/images?num=30&q=larry+bird
+
 \\\\end{CodeBlock}
 
 
@@ -4456,6 +4541,7 @@ you need to encode the URL as:
 
 \\\\begin{CodeBlock}{text}
 http://images.google.com/images?num=30&amp;q=larry+bird
+
 \\\\end{CodeBlock}
 
 
@@ -4479,6 +4565,7 @@ So, if you want to include a copyright symbol in your article, you can write:
 
 \\\\begin{CodeBlock}{text}
 &copy;
+
 \\\\end{CodeBlock}
 
 
@@ -4489,6 +4576,7 @@ and Markdown will leave it alone. But if you write:
 
 \\\\begin{CodeBlock}{text}
 AT&T
+
 \\\\end{CodeBlock}
 
 
@@ -4499,6 +4587,7 @@ Markdown will translate it to:
 
 \\\\begin{CodeBlock}{text}
 AT&amp;T
+
 \\\\end{CodeBlock}
 
 
@@ -4511,6 +4600,7 @@ such. But if you write:
 
 \\\\begin{CodeBlock}{text}
 4 < 5
+
 \\\\end{CodeBlock}
 
 
@@ -4521,6 +4611,7 @@ Markdown will translate it to:
 
 \\\\begin{CodeBlock}{text}
 4 &lt; 5
+
 \\\\end{CodeBlock}
 
 
@@ -4589,6 +4680,7 @@ This is an H1
 
 This is an H2
 -------------
+
 \\\\end{CodeBlock}
 
 
@@ -4608,6 +4700,7 @@ corresponding to header levels 1-6. For example:
 ## This is an H2
 
 ###### This is an H6
+
 \\\\end{CodeBlock}
 
 
@@ -4626,6 +4719,7 @@ determines the header level.) :
 ## This is an H2 ##
 
 ### This is an H3 ######
+
 \\\\end{CodeBlock}
 
 
@@ -4646,6 +4740,7 @@ wrap the text and put a \\\\texttt{>} before every line:
 > 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 > id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -4662,6 +4757,7 @@ Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -4677,6 +4773,7 @@ adding additional levels of \\\\texttt{>}:
 > > This is nested blockquote.
 >
 > Back to the first level.
+
 \\\\end{CodeBlock}
 
 
@@ -4695,6 +4792,7 @@ and code blocks:
 > Here's some example code:
 > 
 >     return shell_exec(\\"echo $input | $markdown_script\\");
+
 \\\\end{CodeBlock}
 
 
@@ -4720,6 +4818,7 @@ Unordered lists use asterisks, pluses, and hyphens -- interchangably
 *   Red
 *   Green
 *   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -4732,6 +4831,7 @@ is equivalent to:
 +   Red
 +   Green
 +   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -4744,6 +4844,7 @@ and:
 -   Red
 -   Green
 -   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -4756,6 +4857,7 @@ Ordered lists use numbers followed by periods:
 1.  Bird
 2.  McHale
 3.  Parish
+
 \\\\end{CodeBlock}
 
 
@@ -4772,6 +4874,7 @@ Markdown produces from the above list is:
 <li>McHale</li>
 <li>Parish</li>
 </ol>
+
 \\\\end{CodeBlock}
 
 
@@ -4784,6 +4887,7 @@ If you instead wrote the list in Markdown like this:
 1.  Bird
 1.  McHale
 1.  Parish
+
 \\\\end{CodeBlock}
 
 
@@ -4796,6 +4900,7 @@ or even:
 3. Bird
 1. McHale
 8. Parish
+
 \\\\end{CodeBlock}
 
 
@@ -4829,6 +4934,7 @@ To make lists look nice, you can wrap items with hanging indents:
     viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
     Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -4843,6 +4949,7 @@ Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
 viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
 Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -4855,6 +4962,7 @@ items in \\\\texttt{<p>} tags in the HTML output. For example, this input:
 \\\\begin{CodeBlock}{text}
 *   Bird
 *   Magic
+
 \\\\end{CodeBlock}
 
 
@@ -4868,6 +4976,7 @@ will turn into:
 <li>Bird</li>
 <li>Magic</li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -4880,6 +4989,7 @@ But this:
 *   Bird
 
 *   Magic
+
 \\\\end{CodeBlock}
 
 
@@ -4893,6 +5003,7 @@ will turn into:
 <li><p>Bird</p></li>
 <li><p>Magic</p></li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -4913,6 +5024,7 @@ or one tab:
     sit amet velit.
 
 2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -4931,6 +5043,7 @@ only required to indent the first line. Lorem ipsum dolor
 sit amet, consectetuer adipiscing elit.
 
 *   Another item in the same list.
+
 \\\\end{CodeBlock}
 
 
@@ -4945,6 +5058,7 @@ delimiters need to be indented:
 
     > This is a blockquote
     > inside a list item.
+
 \\\\end{CodeBlock}
 
 
@@ -4958,6 +5072,7 @@ to be indented \\\\textit{twice} -- 8 spaces or two tabs:
 *   A list item with a code block:
 
         <code goes here>
+
 \\\\end{CodeBlock}
 
 
@@ -4969,6 +5084,7 @@ accident, by writing something like this:
 
 \\\\begin{CodeBlock}{text}
 1986. What a great season.
+
 \\\\end{CodeBlock}
 
 
@@ -4980,6 +5096,7 @@ line. To avoid this, you can backslash-escape the period:
 
 \\\\begin{CodeBlock}{text}
 1986\\\\. What a great season.
+
 \\\\end{CodeBlock}
 
 
@@ -5002,6 +5119,7 @@ block by at least 4 spaces or 1 tab. For example, given this input:
 This is a normal paragraph:
 
     This is a code block.
+
 \\\\end{CodeBlock}
 
 
@@ -5015,6 +5133,7 @@ Markdown will generate:
 
 <pre><code>This is a code block.
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -5030,6 +5149,7 @@ Here is an example of AppleScript:
     tell application \\"Foo\\"
         beep
     end tell
+
 \\\\end{CodeBlock}
 
 
@@ -5045,6 +5165,7 @@ will turn into:
     beep
 end tell
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -5066,6 +5187,7 @@ ampersands and angle brackets. For example, this:
     <div class=\\"footer\\">
         &copy; 2004 Foo Corporation
     </div>
+
 \\\\end{CodeBlock}
 
 
@@ -5079,6 +5201,7 @@ will turn into:
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -5110,6 +5233,7 @@ following lines will produce a horizontal rule:
 ---------------------------------------
 
 _ _ _
+
 \\\\end{CodeBlock}
 
 
@@ -5141,6 +5265,7 @@ title for the link, surrounded in quotes. For example:
 This is [an example](http://example.com/ \\"Title\\") inline link.
 
 [This link](http://example.net/) has no title attribute.
+
 \\\\end{CodeBlock}
 
 
@@ -5155,6 +5280,7 @@ an example</a> inline link.</p>
 
 <p><a href=\\"http://example.net/\\">This link</a> has no
 title attribute.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -5166,6 +5292,7 @@ use relative paths:
 
 \\\\begin{CodeBlock}{text}
 See my [About](/about/) page for details.
+
 \\\\end{CodeBlock}
 
 
@@ -5177,6 +5304,7 @@ which you place a label of your choosing to identify the link:
 
 \\\\begin{CodeBlock}{text}
 This is [an example][id] reference-style link.
+
 \\\\end{CodeBlock}
 
 
@@ -5187,6 +5315,7 @@ You can optionally use a space to separate the sets of brackets:
 
 \\\\begin{CodeBlock}{text}
 This is [an example] [id] reference-style link.
+
 \\\\end{CodeBlock}
 
 
@@ -5198,6 +5327,7 @@ on a line by itself:
 
 \\\\begin{CodeBlock}{text}
 [id]: http://example.com/  \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5223,6 +5353,7 @@ The link URL may, optionally, be surrounded by angle brackets:
 
 \\\\begin{CodeBlock}{text}
 [id]: <http://example.com/>  \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5235,6 +5366,7 @@ or tabs for padding, which tends to look better with longer URLs:
 \\\\begin{CodeBlock}{text}
 [id]: http://example.com/longish/path/to/resource/here
     \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5251,6 +5383,7 @@ Link definition names may constist of letters, numbers, spaces, and punctuation 
 \\\\begin{CodeBlock}{text}
 [link text][a]
 [link text][A]
+
 \\\\end{CodeBlock}
 
 
@@ -5268,6 +5401,7 @@ Just use an empty set of square brackets -- e.g., to link the word
 
 \\\\begin{CodeBlock}{text}
 [Google][]
+
 \\\\end{CodeBlock}
 
 
@@ -5278,6 +5412,7 @@ And then define the link:
 
 \\\\begin{CodeBlock}{text}
 [Google]: http://google.com/
+
 \\\\end{CodeBlock}
 
 
@@ -5289,6 +5424,7 @@ multiple words in the link text:
 
 \\\\begin{CodeBlock}{text}
 Visit [Daring Fireball][] for more information.
+
 \\\\end{CodeBlock}
 
 
@@ -5299,6 +5435,7 @@ And then define the link:
 
 \\\\begin{CodeBlock}{text}
 [Daring Fireball]: http://daringfireball.net/
+
 \\\\end{CodeBlock}
 
 
@@ -5321,6 +5458,7 @@ I get 10 times more traffic from [Google] [1] than from
   [1]: http://google.com/        \\"Google\\"
   [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
   [3]: http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5336,6 +5474,7 @@ I get 10 times more traffic from [Google][] than from
   [google]: http://google.com/        \\"Google\\"
   [yahoo]:  http://search.yahoo.com/  \\"Yahoo Search\\"
   [msn]:    http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5349,6 +5488,7 @@ Both of the above examples will produce the following HTML output:
 title=\\"Google\\">Google</a> than from
 <a href=\\"http://search.yahoo.com/\\" title=\\"Yahoo Search\\">Yahoo</a>
 or <a href=\\"http://search.msn.com/\\" title=\\"MSN Search\\">MSN</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -5362,6 +5502,7 @@ Markdown's inline link style:
 I get 10 times more traffic from [Google](http://google.com/ \\"Google\\")
 than from [Yahoo](http://search.yahoo.com/ \\"Yahoo Search\\") or
 [MSN](http://search.msn.com/ \\"MSN Search\\").
+
 \\\\end{CodeBlock}
 
 
@@ -5401,6 +5542,7 @@ _single underscores_
 **double asterisks**
 
 __double underscores__
+
 \\\\end{CodeBlock}
 
 
@@ -5417,6 +5559,7 @@ will produce:
 <strong>double asterisks</strong>
 
 <strong>double underscores</strong>
+
 \\\\end{CodeBlock}
 
 
@@ -5432,6 +5575,7 @@ Emphasis can be used in the middle of a word:
 
 \\\\begin{CodeBlock}{text}
 un*fucking*believable
+
 \\\\end{CodeBlock}
 
 
@@ -5449,6 +5593,7 @@ escape it:
 
 \\\\begin{CodeBlock}{text}
 \\\\*this text is surrounded by literal asterisks\\\\*
+
 \\\\end{CodeBlock}
 
 
@@ -5463,6 +5608,7 @@ normal paragraph. For example:
 
 \\\\begin{CodeBlock}{text}
 Use the \`printf()\` function.
+
 \\\\end{CodeBlock}
 
 
@@ -5473,6 +5619,7 @@ will produce:
 
 \\\\begin{CodeBlock}{text}
 <p>Use the <code>printf()</code> function.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -5484,6 +5631,7 @@ multiple backticks as the opening and closing delimiters:
 
 \\\\begin{CodeBlock}{text}
 \`\`There is a literal backtick (\`) here.\`\`
+
 \\\\end{CodeBlock}
 
 
@@ -5494,6 +5642,7 @@ which will produce this:
 
 \\\\begin{CodeBlock}{text}
 <p><code>There is a literal backtick (\`) here.</code></p>
+
 \\\\end{CodeBlock}
 
 
@@ -5508,6 +5657,7 @@ literal backtick characters at the beginning or end of a code span:
 A single backtick in a code span: \`\` \` \`\`
 
 A backtick-delimited string in a code span: \`\` \`foo\` \`\`
+
 \\\\end{CodeBlock}
 
 
@@ -5520,6 +5670,7 @@ will produce:
 <p>A single backtick in a code span: <code>\`</code></p>
 
 <p>A backtick-delimited string in a code span: <code>\`foo\`</code></p>
+
 \\\\end{CodeBlock}
 
 
@@ -5532,6 +5683,7 @@ tags. Markdown will turn this:
 
 \\\\begin{CodeBlock}{text}
 Please don't use any \`<blink>\` tags.
+
 \\\\end{CodeBlock}
 
 
@@ -5542,6 +5694,7 @@ into:
 
 \\\\begin{CodeBlock}{text}
 <p>Please don't use any <code>&lt;blink&gt;</code> tags.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -5552,6 +5705,7 @@ You can write this:
 
 \\\\begin{CodeBlock}{text}
 \`&#8212;\` is the decimal-encoded equivalent of \`&mdash;\`.
+
 \\\\end{CodeBlock}
 
 
@@ -5563,6 +5717,7 @@ to produce:
 \\\\begin{CodeBlock}{text}
 <p><code>&amp;#8212;</code> is the decimal-encoded
 equivalent of <code>&amp;mdash;</code>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -5587,6 +5742,7 @@ Inline image syntax looks like this:
 ![Alt text](/path/to/img.jpg)
 
 ![Alt text](/path/to/img.jpg \\"Optional title\\")
+
 \\\\end{CodeBlock}
 
 
@@ -5611,6 +5767,7 @@ Reference-style image syntax looks like this:
 
 \\\\begin{CodeBlock}{text}
 ![Alt text][id]
+
 \\\\end{CodeBlock}
 
 
@@ -5622,6 +5779,7 @@ are defined using syntax identical to link references:
 
 \\\\begin{CodeBlock}{text}
 [id]: url/to/image  \\"Optional title attribute\\"
+
 \\\\end{CodeBlock}
 
 
@@ -5646,6 +5804,7 @@ Markdown supports a shortcut style for creating \\"automatic\\" links for URLs a
 
 \\\\begin{CodeBlock}{text}
 <http://example.com/>
+
 \\\\end{CodeBlock}
 
 
@@ -5656,6 +5815,7 @@ Markdown will turn this into:
 
 \\\\begin{CodeBlock}{text}
 <a href=\\"http://example.com/\\">http://example.com/</a>
+
 \\\\end{CodeBlock}
 
 
@@ -5669,6 +5829,7 @@ spambots. For example, Markdown will turn this:
 
 \\\\begin{CodeBlock}{text}
 <address@example.com>
+
 \\\\end{CodeBlock}
 
 
@@ -5682,6 +5843,7 @@ into something like this:
 &#115;&#115;&#64;&#101;&#120;&#x61;&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;
 &#109;\\">&#x61;&#x64;&#x64;&#x72;&#x65;&#115;&#115;&#64;&#101;&#120;&#x61;
 &#109;&#x70;&#x6C;e&#x2E;&#99;&#111;&#109;</a>
+
 \\\\end{CodeBlock}
 
 
@@ -5709,6 +5871,7 @@ before the asterisks, like this:
 
 \\\\begin{CodeBlock}{text}
 \\\\*literal asterisks\\\\*
+
 \\\\end{CodeBlock}
 
 
@@ -5726,10 +5889,11 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+	plus sign
--	minus sign (hyphen)
++   plus sign
+-   minus sign (hyphen)
 .   dot
 !   exclamation mark
+
 \\\\end{CodeBlock}"
 `;
 
@@ -5739,25 +5903,25 @@ exports[`rebber: remark specs mixed-indentation: mixed-indentation 1`] = `
 
 \\\\begin{itemize}
 \\\\item Very long
-			paragraph
+paragraph
 \\\\end{itemize}
 
 
 \\\\begin{enumerate}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{enumerate}
 
 
 \\\\begin{itemize}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{itemize}
 
 
 \\\\begin{enumerate}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{enumerate}"
 `;
 
@@ -6152,6 +6316,7 @@ Multiple paragraphs:
 \\\\begin{CodeBlock}{text}
 Item 2. graf two. The quick brown fox jumped over the lazy dog's
 back.
+
 \\\\end{CodeBlock}
 
 
@@ -6168,12 +6333,12 @@ exports[`rebber: remark specs paragraphs-and-indentation: paragraphs-and-indenta
 
 
 This is a paragraph
-    and this is further text
+and this is further text
 
 
 
 This is a paragraph
-   and this is further text
+and this is further text
 
 
 
@@ -6183,6 +6348,7 @@ This is a paragraph with some asterisks
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -6204,6 +6370,7 @@ This is a paragraph
 
 \\\\begin{CodeBlock}{text}
 and this is code
+
 \\\\end{CodeBlock}
 
 
@@ -6222,6 +6389,7 @@ This is a paragraph with some asterisks in a code block
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -6379,7 +6547,7 @@ Hyphen should be escaped at the beginning of a line:
 
 - not a list item
 - not a list item
-  + not a list item
++ not a list item
 
 
 
@@ -6396,7 +6564,7 @@ And hash signs:
 
 
 \\\\# not a heading
-  \\\\#\\\\# not a subheading
+\\\\#\\\\# not a subheading
 
 
 
@@ -6552,6 +6720,7 @@ Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
 
 \\\\begin{CodeBlock}{text}
 Test code
+
 \\\\end{CodeBlock}
 
 
@@ -6774,6 +6943,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -6783,7 +6953,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -6793,11 +6964,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}"
 `;
 
@@ -6816,6 +6988,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -6825,7 +6998,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -6835,11 +7009,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}"
 `;
 
@@ -6940,9 +7115,11 @@ exports[`rebber: remark specs task-list: task-list 1`] = `
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
 Hello;
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -6959,9 +7136,11 @@ World;
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
 Hello;
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -6969,9 +7148,11 @@ World;
 \\\\begin{enumerate}
 \\\\item \\\\begin{CodeBlock}{text}
 Foo.
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 Bar.
+
 \\\\end{CodeBlock}
 \\\\end{enumerate}
 
@@ -6982,6 +7163,7 @@ Bar.
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
     Hello;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -6989,13 +7171,15 @@ Bar.
 \\\\begin{enumerate}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{enumerate}
 
 
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
-	Hello;
+    Hello;
+
 \\\\end{CodeBlock}
 \\\\item World.
 \\\\end{itemize}
@@ -7030,7 +7214,7 @@ World;
 
 
 \\\\begin{enumerate}
-\\\\item [ 
+\\\\item [
 ] World;
 \\\\item [		] Hello;
 \\\\item [ 	 ] World.
@@ -7237,8 +7421,8 @@ CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\ \\\\hline
 
 exports[`rebber: remark specs toplevel-paragraphs: toplevel-paragraphs 1`] = `
 "hello world
-    how are you
-    how are you
+how are you
+how are you
 
 
 
@@ -7248,6 +7432,7 @@ hello world
 
 \\\\begin{CodeBlock}{text}
 how are you
+
 \\\\end{CodeBlock}
 
 
@@ -7419,7 +7604,8 @@ Auto-links should not occur here: \\\\texttt{<http://example.com/>}
 
 
 
-[code(or here: <http://example.com/>)]"
+[code(or here: <http://example.com/>
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros auto-link-invalid 1`] = `
@@ -7697,7 +7883,8 @@ Bang: \\\\!
 
 Plus: \\\\+
 
-Minus: \\\\-)]
+Minus: \\\\-
+)]
 
 \\\\textbf{GFM:}
 
@@ -7705,7 +7892,8 @@ Minus: \\\\-)]
 
 [code(Pipe: \\\\|
 
-Tilde: \\\\~)]
+Tilde: \\\\~
+)]
 
 \\\\textbf{Commonmark:}
 
@@ -7740,7 +7928,8 @@ At-sign: \\\\@
 Caret: \\\\^
 
 New line: \\\\
-only works in paragraphs.)]
+only works in paragraphs.
+)]
 
 Nor should these, which occur in code spans:
 
@@ -7928,7 +8117,8 @@ between them.)])]
 [orderedList([listItem(First sublist.)])])])]
 
 
-[code(1.   Second sublist.)]
+[code(1.   Second sublist.
+)]
 
 And for lists followed by indented code blocks:
 
@@ -7937,7 +8127,8 @@ And for lists followed by indented code blocks:
 [unorderedList([listItem(This is a paragraph in a list)])]
 
 
-[code(And this is code();)]"
+[code(And this is code();
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros blockquote-indented 1`] = `
@@ -7947,23 +8138,27 @@ baz)]"
 
 exports[`rebber: remark specs with config: custom macros blockquote-lazy-code 1`] = `
 "[blockquote([code(foo
-bar)])]"
+bar
+)])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros blockquote-lazy-fence 1`] = `
-"[blockquote([code(aNormalCodeBlockInABlockqoute();)])]
+"[blockquote([code(aNormalCodeBlockInABlockqoute();
+)])]
 
 A paragraph.
 
 
 
-[blockquote([code(thisIsAlsoSomeCodeInABlockquote();)])]
+[blockquote([code(thisIsAlsoSomeCodeInABlockquote();
+)])]
 
 A paragraph.
 
 
 
-[blockquote([code(aNonTerminatedCodeBlockInABlockquote();)]aNewCodeBlockFollowingTheBlockQuote();
+[blockquote([code(aNonTerminatedCodeBlockInABlockquote();
+)]aNewCodeBlockFollowingTheBlockQuote();
 
 [code()])]
 
@@ -7973,7 +8168,8 @@ A paragraph.
 
 [blockquote(Something in a blockquote.
 
-[code(aNewCodeBlock();)])]"
+[code(aNewCodeBlock();
+)])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros blockquote-lazy-list 1`] = `
@@ -8015,11 +8211,13 @@ exports[`rebber: remark specs with config: custom macros blockquotes-with-code-b
 
 [code(sub status {
     print \\"working\\";
-})]Or:
+}
+)]Or:
 
 [code(sub status {
     return \\"working\\";
-})])]"
+}
+)])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros bom 1`] = `
@@ -8069,7 +8267,8 @@ exports[`rebber: remark specs with config: custom macros code-block 1`] = `
 
 
 
-[codeJavascript(alert('Hello World!');)]"
+[codeJavascript(alert('Hello World!');
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros code-block-indentation 1`] = `
@@ -8081,7 +8280,8 @@ the code is exdented by up to that amount of spaces.
 
 [code(    This is a code block...
         
-    ...which is not exdented.)]
+    ...which is not exdented.
+)]
 
 But...
 
@@ -8089,7 +8289,8 @@ But...
 
 [code(  This one...
       
-  ...is.)]
+  ...is.
+)]
 
 And...
 
@@ -8097,7 +8298,8 @@ And...
 
 [code(So is this...
       
-  ...one.)]"
+  ...one.
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros code-block-nesting-bug 1`] = `
@@ -8112,7 +8314,8 @@ Note that this bug does not occur on indented code-blocks.
 
 [codeFoo(\`\`\`bar
 baz
-\`\`\`)]
+\`\`\`
+)]
 
 Even with a different fence marker:
 
@@ -8120,7 +8323,8 @@ Even with a different fence marker:
 
 [codeFoo(~~~bar
 baz
-~~~)]
+~~~
+)]
 
 And reversed:
 
@@ -8128,11 +8332,13 @@ And reversed:
 
 [codeFoo(~~~bar
 baz
-~~~)]
+~~~
+)]
 
 [codeFoo(\`\`\`bar
 baz
-\`\`\`)]"
+\`\`\`
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros code-blocks 1`] = `
@@ -8144,20 +8350,23 @@ Regular text.
 
 
 
-[code(code block indented by spaces)]
+[code(code block indented by spaces
+)]
 
 Regular text.
 
 
 
 [code(the lines in this block  
-all contain trailing spaces  )]
+all contain trailing spaces  
+)]
 
 Regular Text.
 
 
 
-[code(code block on the last line)]"
+[code(code block on the last line
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros code-spans 1`] = `
@@ -8189,8 +8398,7 @@ And here, \\\\texttt{\`\`}.
 
 
 
-So is this \\\\texttt{foo   bar
-  baz}.
+So is this \\\\texttt{foo bar baz}.
 
 
 
@@ -8374,7 +8582,8 @@ Entities even work in the language flag of fenced code blocks:
 
 
 
-[codeSome—language(alert('Hello');)]
+[codeSome—language(alert('Hello');
+)]
 
 Or in \\\\externalLink{línks}{\\\\textasciitilde{}/some—file}
 
@@ -8389,7 +8598,8 @@ code blocks:
 
 
 
-[code(C&Ouml;DE block.)]"
+[code(C&Ouml;DE block.
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros entities-advanced 1`] = `
@@ -8397,7 +8607,8 @@ exports[`rebber: remark specs with config: custom macros entities-advanced 1`] =
 
 Entities even work in the language flag of fenced code blocks:
 
-[codeSome©language(alert('Hello');)]And in an auto-link: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com}
+[codeSome©language(alert('Hello');
+)]And in an auto-link: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com}
 
 Foo and bar and \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com} and baz.
 
@@ -8417,7 +8628,7 @@ Or in \\\\includegraphics{undefined}
 pl©ce\\"
 
 [
-  1
+1
 ]: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com} \\"in some
 pl©ce\\")]
 
@@ -8426,20 +8637,25 @@ pl©ce\\")]
 [blockquote(But, entities are not interpreted in \\\\texttt{inline c\\\\&oumlde}, or in
 code blocks:
 
-[code(C&OumlDE block.)])]"
+[code(C&OumlDE block.
+)])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros escaped-angles 1`] = `">"`;
 
 exports[`rebber: remark specs with config: custom macros fenced-code 1`] = `
 "[codeJs(var a = 'hello';
-console.log(a + ' world');)]
+console.log(a + ' world');
+)]
 
-[codeBash(echo \\"hello, \${WORLD}\\")]
+[codeBash(echo \\"hello, \${WORLD}\\"
+)]
 
-[codeLongfence(Q: What do you call a tall person who sells stolen goods?)]
+[codeLongfence(Q: What do you call a tall person who sells stolen goods?
+)]
 
-[codeManyTildes(A longfence!)]"
+[codeManyTildes(A longfence!
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros fenced-code-empty 1`] = `
@@ -8470,15 +8686,21 @@ With nothing:
 
 exports[`rebber: remark specs with config: custom macros fenced-code-trailing-characters 1`] = `
 "[codeJs(foo();
-\`\`\`bash)]"
+\`\`\`bash
+)]"
 `;
 
-exports[`rebber: remark specs with config: custom macros fenced-code-trailing-characters-2 1`] = `"[code(\`\`\` aaa)]"`;
+exports[`rebber: remark specs with config: custom macros fenced-code-trailing-characters-2 1`] = `
+"[code(\`\`\` aaa
+)]"
+`;
 
 exports[`rebber: remark specs with config: custom macros fenced-code-white-space-after-flag 1`] = `
-"[codeJs(foo();)]
+"[codeJs(foo();
+)]
 
-[codeBash(echo \\"hello, \${WORLD}\\")]"
+[codeBash(echo \\"hello, \${WORLD}\\"
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros footnote 1`] = `
@@ -8744,7 +8966,8 @@ exports[`rebber: remark specs with config: custom macros horizontal-rules 1`] = 
 
 [thematicBreak(---)]
 
-[code(---)]
+[code(---
+)]
 
 [thematicBreak(---)]
 
@@ -8754,7 +8977,8 @@ exports[`rebber: remark specs with config: custom macros horizontal-rules 1`] = 
 
 [thematicBreak(---)]
 
-[code(- - -)]
+[code(- - -
+)]
 
 Asterisks:
 
@@ -8768,7 +8992,8 @@ Asterisks:
 
 [thematicBreak(---)]
 
-[code(***)]
+[code(***
+)]
 
 [thematicBreak(---)]
 
@@ -8778,7 +9003,8 @@ Asterisks:
 
 [thematicBreak(---)]
 
-[code(* * *)]
+[code(* * *
+)]
 
 Underscores:
 
@@ -8792,7 +9018,8 @@ Underscores:
 
 [thematicBreak(---)]
 
-[code(___)]
+[code(___
+)]
 
 [thematicBreak(---)]
 
@@ -8802,7 +9029,8 @@ Underscores:
 
 [thematicBreak(---)]
 
-[code(_ _ _)]"
+[code(_ _ _
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros horizontal-rules-adjacent 1`] = `
@@ -9016,14 +9244,16 @@ This should be a code block, though:
 
 
 [code(<div>
-	foo
-</div>)]
+    foo
+</div>
+)]
 
 As should this:
 
 
 
-[code(<div>foo</div>)]
+[code(<div>foo</div>
+)]
 
 Now, nested:
 
@@ -9056,7 +9286,8 @@ Code block:
 
 
 
-[code(<!-- Comment -->)]
+[code(<!-- Comment -->
+)]
 
 Just plain comment, with trailing spaces on the line:
 
@@ -9068,7 +9299,8 @@ Code:
 
 
 
-[code(<hr>)]
+[code(<hr>
+)]
 
 Hr's:
 
@@ -9428,7 +9660,8 @@ Indented [four] times.
 
 [definition(identifier=thrice, url=/url, title=null)]
 
-[code([four]: /url)]
+[code([four]: /url
+)]
 
 [definition(identifier=b, url=/url/, title=null)]
 
@@ -9491,7 +9724,7 @@ breaks)] across lines.
 
 
 
-Here's another where the [linkReference(reference=link breaks, content=link 
+Here's another where the [linkReference(reference=link breaks, content=link
 breaks)] across lines, but with a line-ending space.
 
 
@@ -9511,7 +9744,7 @@ break)].
 
 
 
-This one has a [linkReference(reference=line break, content=line 
+This one has a [linkReference(reference=line break, content=line
 break)] with a line-ending space.
 
 
@@ -10207,7 +10440,8 @@ exports[`rebber: remark specs with config: custom macros list-and-code 1`] = `
 "[unorderedList([listItem(This is a list item)])]
 
 
-[code(This is code)]"
+[code(This is code
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros list-continuation 1`] = `
@@ -10217,7 +10451,8 @@ exports[`rebber: remark specs with config: custom macros list-continuation 1`] =
 
 [orderedList([listItem(foo)])]
 
-[codeJs(code();)]
+[codeJs(code();
+)]
 
 [orderedList([listItem([linkReference(reference=foo, content=foo)])])]
 
@@ -10245,9 +10480,11 @@ World 3b.)][listItem(Hello 4a
 
 World 4a.)][listItem(Hello 4b
 
-World 4b.)][listItem([code(Hello 5a)]World 5a.)][listItem([code(Hello 5b
+World 4b.)][listItem([code(Hello 5a
+)]World 5a.)][listItem([code(Hello 5b
 
-World 5b.)])])]"
+World 5b.
+)])])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros list-item-empty 1`] = `"[unorderedList([listItem(foo)][listItem()][listItem(bar)][listItem(foo)][listItem()][listItem(bar)])]"`;
@@ -10312,28 +10549,33 @@ exports[`rebber: remark specs with config: custom macros lists-with-code-and-rul
 [unorderedList([listItem(three)][listItem(four)][listItem(five)])])])])])])])][listItem(foo:
 
 [code(line 1
-line 2)])][listItem(foo:
+line 2
+)])][listItem(foo:
 
 [orderedList([listItem(foo \\\\texttt{bar} bar:
 
-[codeErb(some code here)])][listItem(foo \\\\texttt{bar} bar:
+[codeErb(some code here
+)])][listItem(foo \\\\texttt{bar} bar:
 
 [codeErb(foo
 ---
 bar
 ---
 foo
-bar)])][listItem(foo \\\\texttt{bar} bar:
+bar
+)])][listItem(foo \\\\texttt{bar} bar:
 
 [codeHtml(---
 foo
 foo
 ---
-bar)])][listItem(foo \\\\texttt{bar} bar:
+bar
+)])][listItem(foo \\\\texttt{bar} bar:
 
 [code(foo
 ---
-bar)])][listItem(foo)])])])]"
+bar
+)])][listItem(foo)])])])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros loose-lists 1`] = `
@@ -10398,8 +10640,8 @@ markdown.js doesnt acknowledge arbitrary html blocks =/</aside>
 [unorderedList([listItem(New List Item 1
 Hi, this is a list item.)][listItem(New List Item 2
 Another item
-    Code goes here.
-    Lots of it...)][listItem(New List Item 3
+Code goes here.
+Lots of it...)][listItem(New List Item 3
 The last item)])])][listItem(List Item 3
 The final item.)][listItem(List Item 4
 The real final item.)])]
@@ -10430,7 +10672,8 @@ And an image with an empty alt attribute \\\\includegraphics{src}.
 
 
 [code(Code goes here.
-Lots of it...)]"
+Lots of it...
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros markdown-documentation-basics 1`] = `
@@ -10517,7 +10760,8 @@ dog's back.
 > 
 > This is the second paragraph in the blockquote.
 >
-> ## This is an H2 in a blockquote)]
+> ## This is an H2 in a blockquote
+)]
 
 Output:
 
@@ -10542,7 +10786,8 @@ dog's back.</p>
     <p>This is the second paragraph in the blockquote.</p>
     
     <h2>This is an H2 in a blockquote</h2>
-</blockquote>)]
+</blockquote>
+)]
 
 heading3(Phrase Emphasis)
 
@@ -10558,7 +10803,8 @@ Markdown:
 Some of these words _are emphasized also_.
 
 Use two asterisks for **strong emphasis**.
-Or, if you prefer, __use two underscores instead__.)]
+Or, if you prefer, __use two underscores instead__.
+)]
 
 Output:
 
@@ -10568,7 +10814,8 @@ Output:
 Some of these words <em>are emphasized also</em>.</p>
 
 <p>Use two asterisks for <strong>strong emphasis</strong>.
-Or, if you prefer, <strong>use two underscores instead</strong>.</p>)]
+Or, if you prefer, <strong>use two underscores instead</strong>.</p>
+)]
 
 heading2(Lists)
 
@@ -10580,7 +10827,8 @@ interchangable; this:
 
 [code(*   Candy.
 *   Gum.
-*   Booze.)]
+*   Booze.
+)]
 
 this:
 
@@ -10588,7 +10836,8 @@ this:
 
 [code(+   Candy.
 +   Gum.
-+   Booze.)]
++   Booze.
+)]
 
 and this:
 
@@ -10596,7 +10845,8 @@ and this:
 
 [code(-   Candy.
 -   Gum.
--   Booze.)]
+-   Booze.
+)]
 
 all produce the same output:
 
@@ -10606,7 +10856,8 @@ all produce the same output:
 <li>Candy.</li>
 <li>Gum.</li>
 <li>Booze.</li>
-</ul>)]
+</ul>
+)]
 
 Ordered (numbered) lists use regular numbers, followed by periods, as
 list markers:
@@ -10615,7 +10866,8 @@ list markers:
 
 [code(1.  Red
 2.  Green
-3.  Blue)]
+3.  Blue
+)]
 
 Output:
 
@@ -10625,7 +10877,8 @@ Output:
 <li>Red</li>
 <li>Green</li>
 <li>Blue</li>
-</ol>)]
+</ol>
+)]
 
 If you put blank lines between items, you'll get \\\\texttt{<p>} tags for the
 list item text. You can create multi-paragraph list items by indenting
@@ -10637,7 +10890,8 @@ the paragraphs by 4 spaces or 1 tab:
 
     With multiple paragraphs.
 
-*   Another item in the list.)]
+*   Another item in the list.
+)]
 
 Output:
 
@@ -10647,7 +10901,8 @@ Output:
 <li><p>A list item.</p>
 <p>With multiple paragraphs.</p></li>
 <li><p>Another item in the list.</p></li>
-</ul>)]
+</ul>
+)]
 
 heading3(Links)
 
@@ -10662,27 +10917,31 @@ For example:
 
 
 
-[code(This is an [example link](http://example.com/).)]
+[code(This is an [example link](http://example.com/).
+)]
 
 Output:
 
 
 
 [code(<p>This is an <a href=\\"http://example.com/\\">
-example link</a>.</p>)]
+example link</a>.</p>
+)]
 
 Optionally, you may include a title attribute in the parentheses:
 
 
 
-[code(This is an [example link](http://example.com/ \\"With a Title\\").)]
+[code(This is an [example link](http://example.com/ \\"With a Title\\").
+)]
 
 Output:
 
 
 
 [code(<p>This is an <a href=\\"http://example.com/\\" title=\\"With a Title\\">
-example link</a>.</p>)]
+example link</a>.</p>
+)]
 
 Reference-style links allow you to refer to your links by names, which
 you define elsewhere in your document:
@@ -10694,7 +10953,8 @@ you define elsewhere in your document:
 
 [1]: http://google.com/        \\"Google\\"
 [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
-[3]: http://search.msn.com/    \\"MSN Search\\")]
+[3]: http://search.msn.com/    \\"MSN Search\\"
+)]
 
 Output:
 
@@ -10703,7 +10963,8 @@ Output:
 [code(<p>I get 10 times more traffic from <a href=\\"http://google.com/\\"
 title=\\"Google\\">Google</a> than from <a href=\\"http://search.yahoo.com/\\"
 title=\\"Yahoo Search\\">Yahoo</a> or <a href=\\"http://search.msn.com/\\"
-title=\\"MSN Search\\">MSN</a>.</p>)]
+title=\\"MSN Search\\">MSN</a>.</p>
+)]
 
 The title attribute is optional. Link names may contain letters,
 numbers and spaces, but are \\\\textit{not} case sensitive:
@@ -10713,14 +10974,16 @@ numbers and spaces, but are \\\\textit{not} case sensitive:
 [code(I start my morning with a cup of coffee and
 [The New York Times][NY Times].
 
-[ny times]: http://www.nytimes.com/)]
+[ny times]: http://www.nytimes.com/
+)]
 
 Output:
 
 
 
 [code(<p>I start my morning with a cup of coffee and
-<a href=\\"http://www.nytimes.com/\\">The New York Times</a>.</p>)]
+<a href=\\"http://www.nytimes.com/\\">The New York Times</a>.</p>
+)]
 
 heading3(Images)
 
@@ -10732,7 +10995,8 @@ Inline (titles are optional):
 
 
 
-[code(![alt text](/path/to/img.jpg \\"Title\\"))]
+[code(![alt text](/path/to/img.jpg \\"Title\\")
+)]
 
 Reference-style:
 
@@ -10740,13 +11004,15 @@ Reference-style:
 
 [code(![alt text][id]
 
-[id]: /path/to/img.jpg \\"Title\\")]
+[id]: /path/to/img.jpg \\"Title\\"
+)]
 
 Both of the above examples produce the same output:
 
 
 
-[code(<img src=\\"/path/to/img.jpg\\" alt=\\"alt text\\" title=\\"Title\\" />)]
+[code(<img src=\\"/path/to/img.jpg\\" alt=\\"alt text\\" title=\\"Title\\" />
+)]
 
 heading3(Code)
 
@@ -10760,7 +11026,8 @@ it easy to use Markdown to write about HTML example code:
 [code(I strongly recommend against using any \`<blink>\` tags.
 
 I wish SmartyPants used named entities like \`&mdash;\`
-instead of decimal-encoded entites like \`&#8212;\`.)]
+instead of decimal-encoded entites like \`&#8212;\`.
+)]
 
 Output:
 
@@ -10771,7 +11038,8 @@ Output:
 
 <p>I wish SmartyPants used named entities like
 <code>&amp;mdash;</code> instead of decimal-encoded
-entites like <code>&amp;#8212;</code>.</p>)]
+entites like <code>&amp;#8212;</code>.</p>
+)]
 
 To specify an entire block of pre-formatted code, indent every line of
 the block by 4 spaces or 1 tab. Just like with code spans, \\\\texttt{\\\\&}, \\\\texttt{<},
@@ -10788,7 +11056,8 @@ you've got to put paragraph tags in your blockquotes:
 
     <blockquote>
         <p>For example.</p>
-    </blockquote>)]
+    </blockquote>
+)]
 
 Output:
 
@@ -10800,7 +11069,8 @@ you've got to put paragraph tags in your blockquotes:</p>
 <pre><code>&lt;blockquote&gt;
     &lt;p&gt;For example.&lt;/p&gt;
 &lt;/blockquote&gt;
-</code></pre>)]"
+</code></pre>
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros markdown-documentation-syntax 1`] = `
@@ -10917,7 +11187,8 @@ For example, to add an HTML table to a Markdown article:
     </tr>
 </table>
 
-This is another regular paragraph.)]
+This is another regular paragraph.
+)]
 
 Note that Markdown formatting syntax is not processed within block-level
 HTML tags. E.g., you can't use Markdown-style \\\\texttt{*emphasis*} inside an
@@ -10954,13 +11225,15 @@ escape ampersands within URLs. Thus, if you want to link to:
 
 
 
-[code(http://images.google.com/images?num=30&q=larry+bird)]
+[code(http://images.google.com/images?num=30&q=larry+bird
+)]
 
 you need to encode the URL as:
 
 
 
-[code(http://images.google.com/images?num=30&amp;q=larry+bird)]
+[code(http://images.google.com/images?num=30&amp;q=larry+bird
+)]
 
 in your anchor tag \\\\texttt{href} attribute. Needless to say, this is easy to
 forget, and is probably the single most common source of HTML validation
@@ -10979,19 +11252,22 @@ So, if you want to include a copyright symbol in your article, you can write:
 
 
 
-[code(&copy;)]
+[code(&copy;
+)]
 
 and Markdown will leave it alone. But if you write:
 
 
 
-[code(AT&T)]
+[code(AT&T
+)]
 
 Markdown will translate it to:
 
 
 
-[code(AT&amp;T)]
+[code(AT&amp;T
+)]
 
 Similarly, because Markdown supports \\\\externalLink{inline HTML}{\\\\#html}, if you use
 angle brackets as delimiters for HTML tags, Markdown will treat them as
@@ -10999,13 +11275,15 @@ such. But if you write:
 
 
 
-[code(4 < 5)]
+[code(4 < 5
+)]
 
 Markdown will translate it to:
 
 
 
-[code(4 &lt; 5)]
+[code(4 &lt; 5
+)]
 
 However, inside Markdown code spans and blocks, angle brackets and
 ampersands are \\\\textit{always} encoded automatically. This makes it easy to use
@@ -11067,7 +11345,8 @@ headers) and dashes (for second-level headers). For example:
 =============
 
 This is an H2
--------------)]
+-------------
+)]
 
 Any number of underlining \\\\texttt{=}'s or \\\\texttt{-}'s will work.
 
@@ -11082,7 +11361,8 @@ corresponding to header levels 1-6. For example:
 
 ## This is an H2
 
-###### This is an H6)]
+###### This is an H6
+)]
 
 Optionally, you may \\"close\\" atx-style headers. This is purely
 cosmetic -- you can use this if you think it looks better. The
@@ -11096,7 +11376,8 @@ determines the header level.) :
 
 ## This is an H2 ##
 
-### This is an H3 ######)]
+### This is an H3 ######
+)]
 
 <h3 id=\\"blockquote\\">Blockquotes</h3>
 
@@ -11112,7 +11393,8 @@ wrap the text and put a \\\\texttt{>} before every line:
 > Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 > 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
-> id sem consectetuer libero luctus adipiscing.)]
+> id sem consectetuer libero luctus adipiscing.
+)]
 
 Markdown allows you to be lazy and only put the \\\\texttt{>} before the first
 line of a hard-wrapped paragraph:
@@ -11124,7 +11406,8 @@ consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
 Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
-id sem consectetuer libero luctus adipiscing.)]
+id sem consectetuer libero luctus adipiscing.
+)]
 
 Blockquotes can be nested (i.e. a blockquote-in-a-blockquote) by
 adding additional levels of \\\\texttt{>}:
@@ -11135,7 +11418,8 @@ adding additional levels of \\\\texttt{>}:
 >
 > > This is nested blockquote.
 >
-> Back to the first level.)]
+> Back to the first level.
+)]
 
 Blockquotes can contain other Markdown elements, including headers, lists,
 and code blocks:
@@ -11149,7 +11433,8 @@ and code blocks:
 > 
 > Here's some example code:
 > 
->     return shell_exec(\\"echo $input | $markdown_script\\");)]
+>     return shell_exec(\\"echo $input | $markdown_script\\");
+)]
 
 Any decent text editor should make email-style quoting easy. For
 example, with BBEdit, you can make a selection and choose Increase
@@ -11170,7 +11455,8 @@ Unordered lists use asterisks, pluses, and hyphens -- interchangably
 
 [code(*   Red
 *   Green
-*   Blue)]
+*   Blue
+)]
 
 is equivalent to:
 
@@ -11178,7 +11464,8 @@ is equivalent to:
 
 [code(+   Red
 +   Green
-+   Blue)]
++   Blue
+)]
 
 and:
 
@@ -11186,7 +11473,8 @@ and:
 
 [code(-   Red
 -   Green
--   Blue)]
+-   Blue
+)]
 
 Ordered lists use numbers followed by periods:
 
@@ -11194,7 +11482,8 @@ Ordered lists use numbers followed by periods:
 
 [code(1.  Bird
 2.  McHale
-3.  Parish)]
+3.  Parish
+)]
 
 It's important to note that the actual numbers you use to mark the
 list have no effect on the HTML output Markdown produces. The HTML
@@ -11206,7 +11495,8 @@ Markdown produces from the above list is:
 <li>Bird</li>
 <li>McHale</li>
 <li>Parish</li>
-</ol>)]
+</ol>
+)]
 
 If you instead wrote the list in Markdown like this:
 
@@ -11214,7 +11504,8 @@ If you instead wrote the list in Markdown like this:
 
 [code(1.  Bird
 1.  McHale
-1.  Parish)]
+1.  Parish
+)]
 
 or even:
 
@@ -11222,7 +11513,8 @@ or even:
 
 [code(3. Bird
 1. McHale
-8. Parish)]
+8. Parish
+)]
 
 you'd get the exact same HTML output. The point is, if you want to,
 you can use ordinal numbers in your ordered Markdown lists, so that
@@ -11251,7 +11543,8 @@ To make lists look nice, you can wrap items with hanging indents:
     Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
     viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
-    Suspendisse id sem consectetuer libero luctus adipiscing.)]
+    Suspendisse id sem consectetuer libero luctus adipiscing.
+)]
 
 But if you want to be lazy, you don't have to:
 
@@ -11261,7 +11554,8 @@ But if you want to be lazy, you don't have to:
 Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
 viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
-Suspendisse id sem consectetuer libero luctus adipiscing.)]
+Suspendisse id sem consectetuer libero luctus adipiscing.
+)]
 
 If list items are separated by blank lines, Markdown will wrap the
 items in \\\\texttt{<p>} tags in the HTML output. For example, this input:
@@ -11269,7 +11563,8 @@ items in \\\\texttt{<p>} tags in the HTML output. For example, this input:
 
 
 [code(*   Bird
-*   Magic)]
+*   Magic
+)]
 
 will turn into:
 
@@ -11278,7 +11573,8 @@ will turn into:
 [code(<ul>
 <li>Bird</li>
 <li>Magic</li>
-</ul>)]
+</ul>
+)]
 
 But this:
 
@@ -11286,7 +11582,8 @@ But this:
 
 [code(*   Bird
 
-*   Magic)]
+*   Magic
+)]
 
 will turn into:
 
@@ -11295,7 +11592,8 @@ will turn into:
 [code(<ul>
 <li><p>Bird</p></li>
 <li><p>Magic</p></li>
-</ul>)]
+</ul>
+)]
 
 List items may consist of multiple paragraphs. Each subsequent
 paragraph in a list item must be intended by either 4 spaces
@@ -11311,7 +11609,8 @@ or one tab:
     vitae, risus. Donec sit amet nisl. Aliquam semper ipsum
     sit amet velit.
 
-2.  Suspendisse id sem consectetuer libero luctus adipiscing.)]
+2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+)]
 
 It looks nice if you indent every line of the subsequent
 paragraphs, but here again, Markdown will allow you to be
@@ -11325,7 +11624,8 @@ lazy:
 only required to indent the first line. Lorem ipsum dolor
 sit amet, consectetuer adipiscing elit.
 
-*   Another item in the same list.)]
+*   Another item in the same list.
+)]
 
 To put a blockquote within a list item, the blockquote's \\\\texttt{>}
 delimiters need to be indented:
@@ -11335,7 +11635,8 @@ delimiters need to be indented:
 [code(*   A list item with a blockquote:
 
     > This is a blockquote
-    > inside a list item.)]
+    > inside a list item.
+)]
 
 To put a code block within a list item, the code block needs
 to be indented \\\\textit{twice} -- 8 spaces or two tabs:
@@ -11344,21 +11645,24 @@ to be indented \\\\textit{twice} -- 8 spaces or two tabs:
 
 [code(*   A list item with a code block:
 
-        <code goes here>)]
+        <code goes here>
+)]
 
 It's worth noting that it's possible to trigger an ordered list by
 accident, by writing something like this:
 
 
 
-[code(1986. What a great season.)]
+[code(1986. What a great season.
+)]
 
 In other words, a \\\\textit{number-period-space} sequence at the beginning of a
 line. To avoid this, you can backslash-escape the period:
 
 
 
-[code(1986\\\\. What a great season.)]
+[code(1986\\\\. What a great season.
+)]
 
 <h3 id=\\"precode\\">Code Blocks</h3>
 
@@ -11376,7 +11680,8 @@ block by at least 4 spaces or 1 tab. For example, given this input:
 
 [code(This is a normal paragraph:
 
-    This is a code block.)]
+    This is a code block.
+)]
 
 Markdown will generate:
 
@@ -11385,7 +11690,8 @@ Markdown will generate:
 [code(<p>This is a normal paragraph:</p>
 
 <pre><code>This is a code block.
-</code></pre>)]
+</code></pre>
+)]
 
 One level of indentation -- 4 spaces or 1 tab -- is removed from each
 line of the code block. For example, this:
@@ -11396,7 +11702,8 @@ line of the code block. For example, this:
 
     tell application \\"Foo\\"
         beep
-    end tell)]
+    end tell
+)]
 
 will turn into:
 
@@ -11407,7 +11714,8 @@ will turn into:
 <pre><code>tell application \\"Foo\\"
     beep
 end tell
-</code></pre>)]
+</code></pre>
+)]
 
 A code block continues until it reaches a line that is not indented
 (or the end of the article).
@@ -11424,7 +11732,8 @@ ampersands and angle brackets. For example, this:
 
 [code(    <div class=\\"footer\\">
         &copy; 2004 Foo Corporation
-    </div>)]
+    </div>
+)]
 
 will turn into:
 
@@ -11433,7 +11742,8 @@ will turn into:
 [code(<pre><code>&lt;div class=\\"footer\\"&gt;
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
-</code></pre>)]
+</code></pre>
+)]
 
 Regular Markdown syntax is not processed within code blocks. E.g.,
 asterisks are just literal asterisks within a code block. This means
@@ -11460,7 +11770,8 @@ following lines will produce a horizontal rule:
 
 ---------------------------------------
 
-_ _ _)]
+_ _ _
+)]
 
 [thematicBreak(---)]
 
@@ -11485,7 +11796,8 @@ title for the link, surrounded in quotes. For example:
 
 [code(This is [an example](http://example.com/ \\"Title\\") inline link.
 
-[This link](http://example.net/) has no title attribute.)]
+[This link](http://example.net/) has no title attribute.
+)]
 
 Will produce:
 
@@ -11495,34 +11807,39 @@ Will produce:
 an example</a> inline link.</p>
 
 <p><a href=\\"http://example.net/\\">This link</a> has no
-title attribute.</p>)]
+title attribute.</p>
+)]
 
 If you're referring to a local resource on the same server, you can
 use relative paths:
 
 
 
-[code(See my [About](/about/) page for details.)]
+[code(See my [About](/about/) page for details.
+)]
 
 Reference-style links use a second set of square brackets, inside
 which you place a label of your choosing to identify the link:
 
 
 
-[code(This is [an example][id] reference-style link.)]
+[code(This is [an example][id] reference-style link.
+)]
 
 You can optionally use a space to separate the sets of brackets:
 
 
 
-[code(This is [an example] [id] reference-style link.)]
+[code(This is [an example] [id] reference-style link.
+)]
 
 Then, anywhere in the document, you define your link label like this,
 on a line by itself:
 
 
 
-[code([id]: http://example.com/  \\"Optional Title Here\\")]
+[code([id]: http://example.com/  \\"Optional Title Here\\"
+)]
 
 That is:
 
@@ -11536,7 +11853,8 @@ The link URL may, optionally, be surrounded by angle brackets:
 
 
 
-[code([id]: <http://example.com/>  \\"Optional Title Here\\")]
+[code([id]: <http://example.com/>  \\"Optional Title Here\\"
+)]
 
 You can put the title attribute on the next line and use extra spaces
 or tabs for padding, which tends to look better with longer URLs:
@@ -11544,7 +11862,8 @@ or tabs for padding, which tends to look better with longer URLs:
 
 
 [code([id]: http://example.com/longish/path/to/resource/here
-    \\"Optional Title Here\\")]
+    \\"Optional Title Here\\"
+)]
 
 Link definitions are only used for creating links during Markdown
 processing, and are stripped from your document in the HTML output.
@@ -11556,7 +11875,8 @@ Link definition names may constist of letters, numbers, spaces, and punctuation 
 
 
 [code([link text][a]
-[link text][A])]
+[link text][A]
+)]
 
 are equivalent.
 
@@ -11569,26 +11889,30 @@ Just use an empty set of square brackets -- e.g., to link the word
 
 
 
-[code([Google][])]
+[code([Google][]
+)]
 
 And then define the link:
 
 
 
-[code([Google]: http://google.com/)]
+[code([Google]: http://google.com/
+)]
 
 Because link names may contain spaces, this shortcut even works for
 multiple words in the link text:
 
 
 
-[code(Visit [Daring Fireball][] for more information.)]
+[code(Visit [Daring Fireball][] for more information.
+)]
 
 And then define the link:
 
 
 
-[code([Daring Fireball]: http://daringfireball.net/)]
+[code([Daring Fireball]: http://daringfireball.net/
+)]
 
 Link definitions can be placed anywhere in your Markdown document. I
 tend to put them immediately after each paragraph in which they're
@@ -11606,7 +11930,8 @@ Here's an example of reference links in action:
 
   [1]: http://google.com/        \\"Google\\"
   [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
-  [3]: http://search.msn.com/    \\"MSN Search\\")]
+  [3]: http://search.msn.com/    \\"MSN Search\\"
+)]
 
 Using the implicit link name shortcut, you could instead write:
 
@@ -11617,7 +11942,8 @@ Using the implicit link name shortcut, you could instead write:
 
   [google]: http://google.com/        \\"Google\\"
   [yahoo]:  http://search.yahoo.com/  \\"Yahoo Search\\"
-  [msn]:    http://search.msn.com/    \\"MSN Search\\")]
+  [msn]:    http://search.msn.com/    \\"MSN Search\\"
+)]
 
 Both of the above examples will produce the following HTML output:
 
@@ -11626,7 +11952,8 @@ Both of the above examples will produce the following HTML output:
 [code(<p>I get 10 times more traffic from <a href=\\"http://google.com/\\"
 title=\\"Google\\">Google</a> than from
 <a href=\\"http://search.yahoo.com/\\" title=\\"Yahoo Search\\">Yahoo</a>
-or <a href=\\"http://search.msn.com/\\" title=\\"MSN Search\\">MSN</a>.</p>)]
+or <a href=\\"http://search.msn.com/\\" title=\\"MSN Search\\">MSN</a>.</p>
+)]
 
 For comparison, here is the same paragraph written using
 Markdown's inline link style:
@@ -11635,7 +11962,8 @@ Markdown's inline link style:
 
 [code(I get 10 times more traffic from [Google](http://google.com/ \\"Google\\")
 than from [Yahoo](http://search.yahoo.com/ \\"Yahoo Search\\") or
-[MSN](http://search.msn.com/ \\"MSN Search\\").)]
+[MSN](http://search.msn.com/ \\"MSN Search\\").
+)]
 
 The point of reference-style links is not that they're easier to
 write. The point is that with reference-style links, your document
@@ -11670,7 +11998,8 @@ _single underscores_
 
 **double asterisks**
 
-__double underscores__)]
+__double underscores__
+)]
 
 will produce:
 
@@ -11682,7 +12011,8 @@ will produce:
 
 <strong>double asterisks</strong>
 
-<strong>double underscores</strong>)]
+<strong>double underscores</strong>
+)]
 
 You can use whichever style you prefer; the lone restriction is that
 the same character must be used to open and close an emphasis span.
@@ -11693,7 +12023,8 @@ Emphasis can be used in the middle of a word:
 
 
 
-[code(un*fucking*believable)]
+[code(un*fucking*believable
+)]
 
 But if you surround an \\\\texttt{*} or \\\\texttt{\\\\_} with spaces, it'll be treated as a
 literal asterisk or underscore.
@@ -11706,7 +12037,8 @@ escape it:
 
 
 
-[code(\\\\*this text is surrounded by literal asterisks\\\\*)]
+[code(\\\\*this text is surrounded by literal asterisks\\\\*
+)]
 
 <h3 id=\\"code\\">Code</h3>
 
@@ -11716,26 +12048,30 @@ normal paragraph. For example:
 
 
 
-[code(Use the \`printf()\` function.)]
+[code(Use the \`printf()\` function.
+)]
 
 will produce:
 
 
 
-[code(<p>Use the <code>printf()</code> function.</p>)]
+[code(<p>Use the <code>printf()</code> function.</p>
+)]
 
 To include a literal backtick character within a code span, you can use
 multiple backticks as the opening and closing delimiters:
 
 
 
-[code(\`\`There is a literal backtick (\`) here.\`\`)]
+[code(\`\`There is a literal backtick (\`) here.\`\`
+)]
 
 which will produce this:
 
 
 
-[code(<p><code>There is a literal backtick (\`) here.</code></p>)]
+[code(<p><code>There is a literal backtick (\`) here.</code></p>
+)]
 
 The backtick delimiters surrounding a code span may include spaces --
 one after the opening, one before the closing. This allows you to place
@@ -11745,7 +12081,8 @@ literal backtick characters at the beginning or end of a code span:
 
 [code(A single backtick in a code span: \`\` \` \`\`
 
-A backtick-delimited string in a code span: \`\` \`foo\` \`\`)]
+A backtick-delimited string in a code span: \`\` \`foo\` \`\`
+)]
 
 will produce:
 
@@ -11753,7 +12090,8 @@ will produce:
 
 [code(<p>A single backtick in a code span: <code>\`</code></p>
 
-<p>A backtick-delimited string in a code span: <code>\`foo\`</code></p>)]
+<p>A backtick-delimited string in a code span: <code>\`foo\`</code></p>
+)]
 
 With a code span, ampersands and angle brackets are encoded as HTML
 entities automatically, which makes it easy to include example HTML
@@ -11761,26 +12099,30 @@ tags. Markdown will turn this:
 
 
 
-[code(Please don't use any \`<blink>\` tags.)]
+[code(Please don't use any \`<blink>\` tags.
+)]
 
 into:
 
 
 
-[code(<p>Please don't use any <code>&lt;blink&gt;</code> tags.</p>)]
+[code(<p>Please don't use any <code>&lt;blink&gt;</code> tags.</p>
+)]
 
 You can write this:
 
 
 
-[code(\`&#8212;\` is the decimal-encoded equivalent of \`&mdash;\`.)]
+[code(\`&#8212;\` is the decimal-encoded equivalent of \`&mdash;\`.
+)]
 
 to produce:
 
 
 
 [code(<p><code>&amp;#8212;</code> is the decimal-encoded
-equivalent of <code>&amp;mdash;</code>.</p>)]
+equivalent of <code>&amp;mdash;</code>.</p>
+)]
 
 <h3 id=\\"img\\">Images</h3>
 
@@ -11800,7 +12142,8 @@ Inline image syntax looks like this:
 
 [code(![Alt text](/path/to/img.jpg)
 
-![Alt text](/path/to/img.jpg \\"Optional title\\"))]
+![Alt text](/path/to/img.jpg \\"Optional title\\")
+)]
 
 That is:
 
@@ -11815,14 +12158,16 @@ Reference-style image syntax looks like this:
 
 
 
-[code(![Alt text][id])]
+[code(![Alt text][id]
+)]
 
 Where \\"id\\" is the name of a defined image reference. Image references
 are defined using syntax identical to link references:
 
 
 
-[code([id]: url/to/image  \\"Optional title attribute\\")]
+[code([id]: url/to/image  \\"Optional title attribute\\"
+)]
 
 As of this writing, Markdown has no syntax for specifying the
 dimensions of an image; if this is important to you, you can simply
@@ -11840,13 +12185,15 @@ Markdown supports a shortcut style for creating \\"automatic\\" links for URLs a
 
 
 
-[code(<http://example.com/>)]
+[code(<http://example.com/>
+)]
 
 Markdown will turn this into:
 
 
 
-[code(<a href=\\"http://example.com/\\">http://example.com/</a>)]
+[code(<a href=\\"http://example.com/\\">http://example.com/</a>
+)]
 
 Automatic links for email addresses work similarly, except that
 Markdown will also perform a bit of randomized decimal and hex
@@ -11855,7 +12202,8 @@ spambots. For example, Markdown will turn this:
 
 
 
-[code(<address@example.com>)]
+[code(<address@example.com>
+)]
 
 into something like this:
 
@@ -11864,7 +12212,8 @@ into something like this:
 [code(<a href=\\"&#x6D;&#x61;i&#x6C;&#x74;&#x6F;:&#x61;&#x64;&#x64;&#x72;&#x65;
 &#115;&#115;&#64;&#101;&#120;&#x61;&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;
 &#109;\\">&#x61;&#x64;&#x64;&#x72;&#x65;&#115;&#115;&#64;&#101;&#120;&#x61;
-&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;&#109;</a>)]
+&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;&#109;</a>
+)]
 
 which will render in a browser as a clickable link to \\"address@example.com\\".
 
@@ -11887,7 +12236,8 @@ before the asterisks, like this:
 
 
 
-[code(\\\\*literal asterisks\\\\*)]
+[code(\\\\*literal asterisks\\\\*
+)]
 
 Markdown provides backslash escapes for the following characters:
 
@@ -11901,26 +12251,27 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+	plus sign
--	minus sign (hyphen)
++   plus sign
+-   minus sign (hyphen)
 .   dot
-!   exclamation mark)]"
+!   exclamation mark
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros mixed-indentation 1`] = `
 "heading1(Mixed spaces and tabs)
 
 [unorderedList([listItem(Very long
-			paragraph)])]
+paragraph)])]
 
 [orderedList([listItem(Very long
-	paragraph)])]
+paragraph)])]
 
 [unorderedList([listItem(Very long
-	paragraph)])]
+paragraph)])]
 
 [orderedList([listItem(Very long
-	paragraph)])]"
+paragraph)])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros nested-blockquotes 1`] = `
@@ -12198,7 +12549,8 @@ Multiple paragraphs:
 
 
 [code(Item 2. graf two. The quick brown fox jumped over the lazy dog's
-back.)]
+back.
+)]
 
 2)	Item 2.
 
@@ -12211,12 +12563,12 @@ exports[`rebber: remark specs with config: custom macros paragraphs-and-indentat
 "heading1(Without lines.)
 
 This is a paragraph
-    and this is further text
+and this is further text
 
 
 
 This is a paragraph
-   and this is further text
+and this is further text
 
 
 
@@ -12224,7 +12576,8 @@ This is a paragraph with some asterisks
 
 
 
-[code(***)]
+[code(***
+)]
 
 This is a paragraph followed by a horizontal rule
 
@@ -12238,7 +12591,8 @@ This is a paragraph
 
 
 
-[code(and this is code)]
+[code(and this is code
+)]
 
 This is a paragraph
 
@@ -12252,7 +12606,8 @@ This is a paragraph with some asterisks in a code block
 
 
 
-[code(***)]
+[code(***
+)]
 
 This is a paragraph followed by a horizontal rule
 
@@ -12393,7 +12748,7 @@ Hyphen should be escaped at the beginning of a line:
 
 - not a list item
 - not a list item
-  + not a list item
++ not a list item
 
 
 
@@ -12410,7 +12765,7 @@ And hash signs:
 
 
 \\\\# not a heading
-  \\\\#\\\\# not a subheading
+\\\\#\\\\# not a subheading
 
 
 
@@ -12545,7 +12900,8 @@ Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-[code(Test code)]
+[code(Test code
+)]
 
 \\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
@@ -12753,23 +13109,26 @@ Code:
 
 
 
-[code(this code block is indented by one tab)]
+[code(this code block is indented by one tab
+)]
 
 And:
 
 
 
-[code(	this code block is indented by two tabs)]
+[code(    this code block is indented by two tabs
+)]
 
 And:
 
 
 
-[code(+	this is an example list item
-	indented with tabs
+[code(+   this is an example list item
+    indented with tabs
 
 +   this is an example list item
-    indented with spaces)]"
+    indented with spaces
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros tabs-and-spaces 1`] = `
@@ -12781,23 +13140,26 @@ Code:
 
 
 
-[code(this code block is indented by one tab)]
+[code(this code block is indented by one tab
+)]
 
 And:
 
 
 
-[code(	this code block is indented by two tabs)]
+[code(    this code block is indented by two tabs
+)]
 
 And:
 
 
 
-[code(+	this is an example list item
-	indented with tabs
+[code(+   this is an example list item
+    indented with tabs
 
 +   this is an example list item
-    indented with spaces)]"
+    indented with spaces
+)]"
 `;
 
 exports[`rebber: remark specs with config: custom macros task-list 1`] = `
@@ -12839,23 +13201,32 @@ heading1(Single tab with content)
 
 heading1(Multiple spaces with content)
 
-[unorderedList([listItem([code(Hello;)])][listItem([code(World;)])])]
+[unorderedList([listItem([code(Hello;
+)])][listItem([code(World;
+)])])]
 
 [orderedList([listItem(Foo.)][listItem(Bar.)])]
 
 heading1(Multiple tabs with content)
 
-[unorderedList([listItem([code(Hello;)])][listItem([code(World;)])])]
+[unorderedList([listItem([code(Hello;
+)])][listItem([code(World;
+)])])]
 
-[orderedList([listItem([code(Foo.)])][listItem([code(Bar.)])])]
+[orderedList([listItem([code(Foo.
+)])][listItem([code(Bar.
+)])])]
 
 heading1(Mixed tabs and spaces)
 
-[unorderedList([listItem([code(    Hello;)])])]
+[unorderedList([listItem([code(    Hello;
+)])])]
 
-[orderedList([listItem([code(World;)])])]
+[orderedList([listItem([code(World;
+)])])]
 
-[unorderedList([listItem([code(	Hello;)])][listItem(World.)])]
+[unorderedList([listItem([code(    Hello;
+)])][listItem(World.)])]
 
 [orderedList([listItem(Bar.)])]
 
@@ -12871,7 +13242,7 @@ heading1(Multiple unfinished characters)
 
 [unorderedList([listItem([  ] Hello;)])]
 
-[orderedList([listItem([ 
+[orderedList([listItem([
 ] World;)][listItem([		] Hello;)][listItem([ 	 ] World.)])]"
 `;
 
@@ -13031,8 +13402,8 @@ heading2(Single quotes)
 
 exports[`rebber: remark specs with config: custom macros toplevel-paragraphs 1`] = `
 "hello world
-    how are you
-    how are you
+how are you
+how are you
 
 
 
@@ -13040,7 +13411,8 @@ hello world
 
 
 
-[code(how are you)]
+[code(how are you
+)]
 
 hello world
 
@@ -13198,6 +13570,7 @@ Auto-links should not occur here: \\\\texttt{<http://example.com/>}
 
 \\\\begin{CodeBlock}{text}
 or here: <http://example.com/>
+
 \\\\end{CodeBlock}
 
 "
@@ -13490,6 +13863,7 @@ Bang: \\\\!
 Plus: \\\\+
 
 Minus: \\\\-
+
 \\\\end{CodeBlock}
 
 
@@ -13502,6 +13876,7 @@ Minus: \\\\-
 Pipe: \\\\|
 
 Tilde: \\\\~
+
 \\\\end{CodeBlock}
 
 
@@ -13541,6 +13916,7 @@ Caret: \\\\^
 
 New line: \\\\
 only works in paragraphs.
+
 \\\\end{CodeBlock}
 
 
@@ -13755,6 +14131,7 @@ between them.
 
 \\\\begin{CodeBlock}{text}
 1.   Second sublist.
+
 \\\\end{CodeBlock}
 
 
@@ -13771,6 +14148,7 @@ And for lists followed by indented code blocks:
 
 \\\\begin{CodeBlock}{text}
 And this is code();
+
 \\\\end{CodeBlock}
 
 "
@@ -13790,6 +14168,7 @@ exports[`toLaTeX: remark specs blockquote-lazy-code: blockquote-lazy-code 1`] = 
 \\\\begin{CodeBlock}{text}
 foo
 bar
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -13800,6 +14179,7 @@ exports[`toLaTeX: remark specs blockquote-lazy-fence: blockquote-lazy-fence 1`] 
 "\\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 aNormalCodeBlockInABlockqoute();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -13812,6 +14192,7 @@ A paragraph.
 \\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 thisIsAlsoSomeCodeInABlockquote();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -13824,6 +14205,7 @@ A paragraph.
 \\\\begin{Quotation}
 \\\\begin{CodeBlock}{text}
 aNonTerminatedCodeBlockInABlockquote();
+
 \\\\end{CodeBlock}
 
 aNewCodeBlockFollowingTheBlockQuote();
@@ -13844,6 +14226,7 @@ Something in a blockquote.
 
 \\\\begin{CodeBlock}{text}
 aNewCodeBlock();
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -13915,6 +14298,7 @@ Example:
 sub status {
     print \\"working\\";
 }
+
 \\\\end{CodeBlock}
 
 Or:
@@ -13923,6 +14307,7 @@ Or:
 sub status {
     return \\"working\\";
 }
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -13985,6 +14370,7 @@ exports[`toLaTeX: remark specs code-block: code-block 1`] = `
 
 \\\\begin{CodeBlock}{javascript}
 alert('Hello World!');
+
 \\\\end{CodeBlock}
 
 "
@@ -14001,6 +14387,7 @@ the code is exdented by up to that amount of spaces.
     This is a code block...
         
     ...which is not exdented.
+
 \\\\end{CodeBlock}
 
 
@@ -14013,6 +14400,7 @@ But...
   This one...
       
   ...is.
+
 \\\\end{CodeBlock}
 
 
@@ -14025,6 +14413,7 @@ And...
 So is this...
       
   ...one.
+
 \\\\end{CodeBlock}
 
 "
@@ -14044,6 +14433,7 @@ Note that this bug does not occur on indented code-blocks.
 \`\`\`bar
 baz
 \`\`\`
+
 \\\\end{CodeBlock}
 
 
@@ -14056,6 +14446,7 @@ Even with a different fence marker:
 ~~~bar
 baz
 ~~~
+
 \\\\end{CodeBlock}
 
 
@@ -14068,6 +14459,7 @@ And reversed:
 ~~~bar
 baz
 ~~~
+
 \\\\end{CodeBlock}
 
 
@@ -14076,6 +14468,7 @@ baz
 \`\`\`bar
 baz
 \`\`\`
+
 \\\\end{CodeBlock}
 
 "
@@ -14092,6 +14485,7 @@ Regular text.
 
 \\\\begin{CodeBlock}{text}
 code block indented by spaces
+
 \\\\end{CodeBlock}
 
 
@@ -14103,6 +14497,7 @@ Regular text.
 \\\\begin{CodeBlock}{text}
 the lines in this block  
 all contain trailing spaces  
+
 \\\\end{CodeBlock}
 
 
@@ -14113,6 +14508,7 @@ Regular Text.
 
 \\\\begin{CodeBlock}{text}
 code block on the last line
+
 \\\\end{CodeBlock}
 
 "
@@ -14147,8 +14543,7 @@ And here, \\\\texttt{\`\`}.
 
 
 
-So is this \\\\texttt{foo   bar
-  baz}.
+So is this \\\\texttt{foo bar baz}.
 
 
 
@@ -14380,6 +14775,7 @@ Entities even work in the language flag of fenced code blocks:
 
 \\\\begin{CodeBlock}{some—language}
 alert('Hello');
+
 \\\\end{CodeBlock}
 
 
@@ -14399,6 +14795,7 @@ code blocks:
 
 \\\\begin{CodeBlock}{text}
 C&Ouml;DE block.
+
 \\\\end{CodeBlock}
 
 "
@@ -14412,6 +14809,7 @@ Entities even work in the language flag of fenced code blocks:
 
 \\\\begin{CodeBlock}{some©language}
 alert('Hello');
+
 \\\\end{CodeBlock}
 
 And in an auto-link: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com}
@@ -14440,7 +14838,7 @@ Or in \\\\includegraphics{undefined}
 pl©ce\\"
 
 [
-  1
+1
 ]: \\\\externalLink{http://example©xample.com}{http://example\\\\&copyxample.com} \\"in some
 pl©ce\\"
 \\\\end{Quotation}
@@ -14457,6 +14855,7 @@ code blocks:
 
 \\\\begin{CodeBlock}{text}
 C&OumlDE block.
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -14473,24 +14872,28 @@ exports[`toLaTeX: remark specs fenced-code: fenced-code 1`] = `
 "\\\\begin{CodeBlock}{js}
 var a = 'hello';
 console.log(a + ' world');
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{bash}
 echo \\"hello, \${WORLD}\\"
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{longfence}
 Q: What do you call a tall person who sells stolen goods?
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{ManyTildes}
 A longfence!
+
 \\\\end{CodeBlock}
 
 "
@@ -14542,6 +14945,7 @@ exports[`toLaTeX: remark specs fenced-code-trailing-characters: fenced-code-trai
 "\\\\begin{CodeBlock}{js}
 foo();
 \`\`\`bash
+
 \\\\end{CodeBlock}
 
 "
@@ -14550,6 +14954,7 @@ foo();
 exports[`toLaTeX: remark specs fenced-code-trailing-characters-2: fenced-code-trailing-characters-2 1`] = `
 "\\\\begin{CodeBlock}{text}
 \`\`\` aaa
+
 \\\\end{CodeBlock}
 
 "
@@ -14558,12 +14963,14 @@ exports[`toLaTeX: remark specs fenced-code-trailing-characters-2: fenced-code-tr
 exports[`toLaTeX: remark specs fenced-code-white-space-after-flag: fenced-code-white-space-after-flag 1`] = `
 "\\\\begin{CodeBlock}{js}
 foo();
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{bash}
 echo \\"hello, \${WORLD}\\"
+
 \\\\end{CodeBlock}
 
 "
@@ -14905,6 +15312,7 @@ exports[`toLaTeX: remark specs horizontal-rules: horizontal-rules 1`] = `
 
 \\\\begin{CodeBlock}{text}
 ---
+
 \\\\end{CodeBlock}
 
 
@@ -14927,6 +15335,7 @@ exports[`toLaTeX: remark specs horizontal-rules: horizontal-rules 1`] = `
 
 \\\\begin{CodeBlock}{text}
 - - -
+
 \\\\end{CodeBlock}
 
 
@@ -14953,6 +15362,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -14975,6 +15385,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 * * *
+
 \\\\end{CodeBlock}
 
 
@@ -15001,6 +15412,7 @@ Underscores:
 
 \\\\begin{CodeBlock}{text}
 ___
+
 \\\\end{CodeBlock}
 
 
@@ -15023,6 +15435,7 @@ ___
 
 \\\\begin{CodeBlock}{text}
 _ _ _
+
 \\\\end{CodeBlock}
 
 "
@@ -15295,8 +15708,9 @@ This should be a code block, though:
 
 \\\\begin{CodeBlock}{text}
 <div>
-	foo
+    foo
 </div>
+
 \\\\end{CodeBlock}
 
 
@@ -15307,6 +15721,7 @@ As should this:
 
 \\\\begin{CodeBlock}{text}
 <div>foo</div>
+
 \\\\end{CodeBlock}
 
 
@@ -15344,6 +15759,7 @@ Code block:
 
 \\\\begin{CodeBlock}{text}
 <!-- Comment -->
+
 \\\\end{CodeBlock}
 
 
@@ -15360,6 +15776,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 <hr>
+
 \\\\end{CodeBlock}
 
 
@@ -15762,6 +16179,7 @@ Indented [four] times.
 
 \\\\begin{CodeBlock}{text}
 [four]: /url
+
 \\\\end{CodeBlock}
 
 
@@ -15831,7 +16249,7 @@ breaks\\\\ref{link breaks} across lines.
 
 
 
-Here's another where the link 
+Here's another where the link
 breaks\\\\ref{link breaks} across lines, but with a line-ending space.
 
 
@@ -15851,7 +16269,7 @@ break\\\\ref{line break}.
 
 
 
-This one has a line 
+This one has a line
 break\\\\ref{line break} with a line-ending space.
 
 
@@ -16647,6 +17065,7 @@ exports[`toLaTeX: remark specs list-and-code: list-and-code 1`] = `
 
 \\\\begin{CodeBlock}{text}
 This is code
+
 \\\\end{CodeBlock}
 
 "
@@ -16669,6 +17088,7 @@ exports[`toLaTeX: remark specs list-continuation: list-continuation 1`] = `
 
 \\\\begin{CodeBlock}{js}
 code();
+
 \\\\end{CodeBlock}
 
 
@@ -16716,6 +17136,7 @@ World 4a.
 World 4b.
 \\\\item \\\\begin{CodeBlock}{text}
 Hello 5a
+
 \\\\end{CodeBlock}
 
 World 5a.
@@ -16723,6 +17144,7 @@ World 5a.
 Hello 5b
 
 World 5b.
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 "
@@ -16862,6 +17284,7 @@ exports[`toLaTeX: remark specs lists-with-code-and-rules: lists-with-code-and-ru
 \\\\begin{CodeBlock}{text}
 line 1
 line 2
+
 \\\\end{CodeBlock}
 \\\\item foo:
 
@@ -16870,6 +17293,7 @@ line 2
 
 \\\\begin{CodeBlock}{erb}
 some code here
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -16880,6 +17304,7 @@ bar
 ---
 foo
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -16889,6 +17314,7 @@ foo
 foo
 ---
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo \\\\texttt{bar} bar:
 
@@ -16896,6 +17322,7 @@ bar
 foo
 ---
 bar
+
 \\\\end{CodeBlock}
 \\\\item foo
 \\\\end{enumerate}
@@ -17006,8 +17433,8 @@ markdown.js doesnt acknowledge arbitrary html blocks =/</aside>
 Hi, this is a list item.
 \\\\item New List Item 2
 Another item
-    Code goes here.
-    Lots of it...
+Code goes here.
+Lots of it...
 \\\\item New List Item 3
 The last item
 \\\\end{itemize}
@@ -17063,6 +17490,7 @@ And an image with an empty alt attribute \\\\includegraphics{src}.
 \\\\begin{CodeBlock}{text}
 Code goes here.
 Lots of it...
+
 \\\\end{CodeBlock}
 
 "
@@ -17157,6 +17585,7 @@ dog's back.
 > This is the second paragraph in the blockquote.
 >
 > ## This is an H2 in a blockquote
+
 \\\\end{CodeBlock}
 
 
@@ -17186,6 +17615,7 @@ dog's back.</p>
     
     <h2>This is an H2 in a blockquote</h2>
 </blockquote>
+
 \\\\end{CodeBlock}
 
 
@@ -17207,6 +17637,7 @@ Some of these words _are emphasized also_.
 
 Use two asterisks for **strong emphasis**.
 Or, if you prefer, __use two underscores instead__.
+
 \\\\end{CodeBlock}
 
 
@@ -17221,6 +17652,7 @@ Some of these words <em>are emphasized also</em>.</p>
 
 <p>Use two asterisks for <strong>strong emphasis</strong>.
 Or, if you prefer, <strong>use two underscores instead</strong>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17238,6 +17670,7 @@ interchangable; this:
 *   Candy.
 *   Gum.
 *   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -17250,6 +17683,7 @@ this:
 +   Candy.
 +   Gum.
 +   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -17262,6 +17696,7 @@ and this:
 -   Candy.
 -   Gum.
 -   Booze.
+
 \\\\end{CodeBlock}
 
 
@@ -17276,6 +17711,7 @@ all produce the same output:
 <li>Gum.</li>
 <li>Booze.</li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -17289,6 +17725,7 @@ list markers:
 1.  Red
 2.  Green
 3.  Blue
+
 \\\\end{CodeBlock}
 
 
@@ -17303,6 +17740,7 @@ Output:
 <li>Green</li>
 <li>Blue</li>
 </ol>
+
 \\\\end{CodeBlock}
 
 
@@ -17319,6 +17757,7 @@ the paragraphs by 4 spaces or 1 tab:
     With multiple paragraphs.
 
 *   Another item in the list.
+
 \\\\end{CodeBlock}
 
 
@@ -17333,6 +17772,7 @@ Output:
 <p>With multiple paragraphs.</p></li>
 <li><p>Another item in the list.</p></li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -17353,6 +17793,7 @@ For example:
 
 \\\\begin{CodeBlock}{text}
 This is an [example link](http://example.com/).
+
 \\\\end{CodeBlock}
 
 
@@ -17364,6 +17805,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>This is an <a href=\\"http://example.com/\\">
 example link</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17374,6 +17816,7 @@ Optionally, you may include a title attribute in the parentheses:
 
 \\\\begin{CodeBlock}{text}
 This is an [example link](http://example.com/ \\"With a Title\\").
+
 \\\\end{CodeBlock}
 
 
@@ -17385,6 +17828,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>This is an <a href=\\"http://example.com/\\" title=\\"With a Title\\">
 example link</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17401,6 +17845,7 @@ I get 10 times more traffic from [Google][1] than from
 [1]: http://google.com/        \\"Google\\"
 [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
 [3]: http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -17414,6 +17859,7 @@ Output:
 title=\\"Google\\">Google</a> than from <a href=\\"http://search.yahoo.com/\\"
 title=\\"Yahoo Search\\">Yahoo</a> or <a href=\\"http://search.msn.com/\\"
 title=\\"MSN Search\\">MSN</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17428,6 +17874,7 @@ I start my morning with a cup of coffee and
 [The New York Times][NY Times].
 
 [ny times]: http://www.nytimes.com/
+
 \\\\end{CodeBlock}
 
 
@@ -17439,6 +17886,7 @@ Output:
 \\\\begin{CodeBlock}{text}
 <p>I start my morning with a cup of coffee and
 <a href=\\"http://www.nytimes.com/\\">The New York Times</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17456,6 +17904,7 @@ Inline (titles are optional):
 
 \\\\begin{CodeBlock}{text}
 ![alt text](/path/to/img.jpg \\"Title\\")
+
 \\\\end{CodeBlock}
 
 
@@ -17468,6 +17917,7 @@ Reference-style:
 ![alt text][id]
 
 [id]: /path/to/img.jpg \\"Title\\"
+
 \\\\end{CodeBlock}
 
 
@@ -17478,6 +17928,7 @@ Both of the above examples produce the same output:
 
 \\\\begin{CodeBlock}{text}
 <img src=\\"/path/to/img.jpg\\" alt=\\"alt text\\" title=\\"Title\\" />
+
 \\\\end{CodeBlock}
 
 
@@ -17497,6 +17948,7 @@ I strongly recommend against using any \`<blink>\` tags.
 
 I wish SmartyPants used named entities like \`&mdash;\`
 instead of decimal-encoded entites like \`&#8212;\`.
+
 \\\\end{CodeBlock}
 
 
@@ -17512,6 +17964,7 @@ Output:
 <p>I wish SmartyPants used named entities like
 <code>&amp;mdash;</code> instead of decimal-encoded
 entites like <code>&amp;#8212;</code>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -17533,6 +17986,7 @@ you've got to put paragraph tags in your blockquotes:
     <blockquote>
         <p>For example.</p>
     </blockquote>
+
 \\\\end{CodeBlock}
 
 
@@ -17549,6 +18003,7 @@ you've got to put paragraph tags in your blockquotes:</p>
     &lt;p&gt;For example.&lt;/p&gt;
 &lt;/blockquote&gt;
 </code></pre>
+
 \\\\end{CodeBlock}
 
 "
@@ -17698,6 +18153,7 @@ This is a regular paragraph.
 </table>
 
 This is another regular paragraph.
+
 \\\\end{CodeBlock}
 
 
@@ -17739,6 +18195,7 @@ escape ampersands within URLs. Thus, if you want to link to:
 
 \\\\begin{CodeBlock}{text}
 http://images.google.com/images?num=30&q=larry+bird
+
 \\\\end{CodeBlock}
 
 
@@ -17749,6 +18206,7 @@ you need to encode the URL as:
 
 \\\\begin{CodeBlock}{text}
 http://images.google.com/images?num=30&amp;q=larry+bird
+
 \\\\end{CodeBlock}
 
 
@@ -17772,6 +18230,7 @@ So, if you want to include a copyright symbol in your article, you can write:
 
 \\\\begin{CodeBlock}{text}
 &copy;
+
 \\\\end{CodeBlock}
 
 
@@ -17782,6 +18241,7 @@ and Markdown will leave it alone. But if you write:
 
 \\\\begin{CodeBlock}{text}
 AT&T
+
 \\\\end{CodeBlock}
 
 
@@ -17792,6 +18252,7 @@ Markdown will translate it to:
 
 \\\\begin{CodeBlock}{text}
 AT&amp;T
+
 \\\\end{CodeBlock}
 
 
@@ -17804,6 +18265,7 @@ such. But if you write:
 
 \\\\begin{CodeBlock}{text}
 4 < 5
+
 \\\\end{CodeBlock}
 
 
@@ -17814,6 +18276,7 @@ Markdown will translate it to:
 
 \\\\begin{CodeBlock}{text}
 4 &lt; 5
+
 \\\\end{CodeBlock}
 
 
@@ -17882,6 +18345,7 @@ This is an H1
 
 This is an H2
 -------------
+
 \\\\end{CodeBlock}
 
 
@@ -17901,6 +18365,7 @@ corresponding to header levels 1-6. For example:
 ## This is an H2
 
 ###### This is an H6
+
 \\\\end{CodeBlock}
 
 
@@ -17919,6 +18384,7 @@ determines the header level.) :
 ## This is an H2 ##
 
 ### This is an H3 ######
+
 \\\\end{CodeBlock}
 
 
@@ -17939,6 +18405,7 @@ wrap the text and put a \\\\texttt{>} before every line:
 > 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 > id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -17955,6 +18422,7 @@ Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
 
 > Donec sit amet nisl. Aliquam semper ipsum sit amet velit. Suspendisse
 id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -17970,6 +18438,7 @@ adding additional levels of \\\\texttt{>}:
 > > This is nested blockquote.
 >
 > Back to the first level.
+
 \\\\end{CodeBlock}
 
 
@@ -17988,6 +18457,7 @@ and code blocks:
 > Here's some example code:
 > 
 >     return shell_exec(\\"echo $input | $markdown_script\\");
+
 \\\\end{CodeBlock}
 
 
@@ -18013,6 +18483,7 @@ Unordered lists use asterisks, pluses, and hyphens -- interchangably
 *   Red
 *   Green
 *   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -18025,6 +18496,7 @@ is equivalent to:
 +   Red
 +   Green
 +   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -18037,6 +18509,7 @@ and:
 -   Red
 -   Green
 -   Blue
+
 \\\\end{CodeBlock}
 
 
@@ -18049,6 +18522,7 @@ Ordered lists use numbers followed by periods:
 1.  Bird
 2.  McHale
 3.  Parish
+
 \\\\end{CodeBlock}
 
 
@@ -18065,6 +18539,7 @@ Markdown produces from the above list is:
 <li>McHale</li>
 <li>Parish</li>
 </ol>
+
 \\\\end{CodeBlock}
 
 
@@ -18077,6 +18552,7 @@ If you instead wrote the list in Markdown like this:
 1.  Bird
 1.  McHale
 1.  Parish
+
 \\\\end{CodeBlock}
 
 
@@ -18089,6 +18565,7 @@ or even:
 3. Bird
 1. McHale
 8. Parish
+
 \\\\end{CodeBlock}
 
 
@@ -18122,6 +18599,7 @@ To make lists look nice, you can wrap items with hanging indents:
     viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
     Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -18136,6 +18614,7 @@ Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi,
 viverra nec, fringilla in, laoreet vitae, risus.
 *   Donec sit amet nisl. Aliquam semper ipsum sit amet velit.
 Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -18148,6 +18627,7 @@ items in \\\\texttt{<p>} tags in the HTML output. For example, this input:
 \\\\begin{CodeBlock}{text}
 *   Bird
 *   Magic
+
 \\\\end{CodeBlock}
 
 
@@ -18161,6 +18641,7 @@ will turn into:
 <li>Bird</li>
 <li>Magic</li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -18173,6 +18654,7 @@ But this:
 *   Bird
 
 *   Magic
+
 \\\\end{CodeBlock}
 
 
@@ -18186,6 +18668,7 @@ will turn into:
 <li><p>Bird</p></li>
 <li><p>Magic</p></li>
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -18206,6 +18689,7 @@ or one tab:
     sit amet velit.
 
 2.  Suspendisse id sem consectetuer libero luctus adipiscing.
+
 \\\\end{CodeBlock}
 
 
@@ -18224,6 +18708,7 @@ only required to indent the first line. Lorem ipsum dolor
 sit amet, consectetuer adipiscing elit.
 
 *   Another item in the same list.
+
 \\\\end{CodeBlock}
 
 
@@ -18238,6 +18723,7 @@ delimiters need to be indented:
 
     > This is a blockquote
     > inside a list item.
+
 \\\\end{CodeBlock}
 
 
@@ -18251,6 +18737,7 @@ to be indented \\\\textit{twice} -- 8 spaces or two tabs:
 *   A list item with a code block:
 
         <code goes here>
+
 \\\\end{CodeBlock}
 
 
@@ -18262,6 +18749,7 @@ accident, by writing something like this:
 
 \\\\begin{CodeBlock}{text}
 1986. What a great season.
+
 \\\\end{CodeBlock}
 
 
@@ -18273,6 +18761,7 @@ line. To avoid this, you can backslash-escape the period:
 
 \\\\begin{CodeBlock}{text}
 1986\\\\. What a great season.
+
 \\\\end{CodeBlock}
 
 
@@ -18295,6 +18784,7 @@ block by at least 4 spaces or 1 tab. For example, given this input:
 This is a normal paragraph:
 
     This is a code block.
+
 \\\\end{CodeBlock}
 
 
@@ -18308,6 +18798,7 @@ Markdown will generate:
 
 <pre><code>This is a code block.
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -18323,6 +18814,7 @@ Here is an example of AppleScript:
     tell application \\"Foo\\"
         beep
     end tell
+
 \\\\end{CodeBlock}
 
 
@@ -18338,6 +18830,7 @@ will turn into:
     beep
 end tell
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -18359,6 +18852,7 @@ ampersands and angle brackets. For example, this:
     <div class=\\"footer\\">
         &copy; 2004 Foo Corporation
     </div>
+
 \\\\end{CodeBlock}
 
 
@@ -18372,6 +18866,7 @@ will turn into:
     &amp;copy; 2004 Foo Corporation
 &lt;/div&gt;
 </code></pre>
+
 \\\\end{CodeBlock}
 
 
@@ -18403,6 +18898,7 @@ following lines will produce a horizontal rule:
 ---------------------------------------
 
 _ _ _
+
 \\\\end{CodeBlock}
 
 
@@ -18434,6 +18930,7 @@ title for the link, surrounded in quotes. For example:
 This is [an example](http://example.com/ \\"Title\\") inline link.
 
 [This link](http://example.net/) has no title attribute.
+
 \\\\end{CodeBlock}
 
 
@@ -18448,6 +18945,7 @@ an example</a> inline link.</p>
 
 <p><a href=\\"http://example.net/\\">This link</a> has no
 title attribute.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -18459,6 +18957,7 @@ use relative paths:
 
 \\\\begin{CodeBlock}{text}
 See my [About](/about/) page for details.
+
 \\\\end{CodeBlock}
 
 
@@ -18470,6 +18969,7 @@ which you place a label of your choosing to identify the link:
 
 \\\\begin{CodeBlock}{text}
 This is [an example][id] reference-style link.
+
 \\\\end{CodeBlock}
 
 
@@ -18480,6 +18980,7 @@ You can optionally use a space to separate the sets of brackets:
 
 \\\\begin{CodeBlock}{text}
 This is [an example] [id] reference-style link.
+
 \\\\end{CodeBlock}
 
 
@@ -18491,6 +18992,7 @@ on a line by itself:
 
 \\\\begin{CodeBlock}{text}
 [id]: http://example.com/  \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18516,6 +19018,7 @@ The link URL may, optionally, be surrounded by angle brackets:
 
 \\\\begin{CodeBlock}{text}
 [id]: <http://example.com/>  \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18528,6 +19031,7 @@ or tabs for padding, which tends to look better with longer URLs:
 \\\\begin{CodeBlock}{text}
 [id]: http://example.com/longish/path/to/resource/here
     \\"Optional Title Here\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18544,6 +19048,7 @@ Link definition names may constist of letters, numbers, spaces, and punctuation 
 \\\\begin{CodeBlock}{text}
 [link text][a]
 [link text][A]
+
 \\\\end{CodeBlock}
 
 
@@ -18561,6 +19066,7 @@ Just use an empty set of square brackets -- e.g., to link the word
 
 \\\\begin{CodeBlock}{text}
 [Google][]
+
 \\\\end{CodeBlock}
 
 
@@ -18571,6 +19077,7 @@ And then define the link:
 
 \\\\begin{CodeBlock}{text}
 [Google]: http://google.com/
+
 \\\\end{CodeBlock}
 
 
@@ -18582,6 +19089,7 @@ multiple words in the link text:
 
 \\\\begin{CodeBlock}{text}
 Visit [Daring Fireball][] for more information.
+
 \\\\end{CodeBlock}
 
 
@@ -18592,6 +19100,7 @@ And then define the link:
 
 \\\\begin{CodeBlock}{text}
 [Daring Fireball]: http://daringfireball.net/
+
 \\\\end{CodeBlock}
 
 
@@ -18614,6 +19123,7 @@ I get 10 times more traffic from [Google] [1] than from
   [1]: http://google.com/        \\"Google\\"
   [2]: http://search.yahoo.com/  \\"Yahoo Search\\"
   [3]: http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18629,6 +19139,7 @@ I get 10 times more traffic from [Google][] than from
   [google]: http://google.com/        \\"Google\\"
   [yahoo]:  http://search.yahoo.com/  \\"Yahoo Search\\"
   [msn]:    http://search.msn.com/    \\"MSN Search\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18642,6 +19153,7 @@ Both of the above examples will produce the following HTML output:
 title=\\"Google\\">Google</a> than from
 <a href=\\"http://search.yahoo.com/\\" title=\\"Yahoo Search\\">Yahoo</a>
 or <a href=\\"http://search.msn.com/\\" title=\\"MSN Search\\">MSN</a>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -18655,6 +19167,7 @@ Markdown's inline link style:
 I get 10 times more traffic from [Google](http://google.com/ \\"Google\\")
 than from [Yahoo](http://search.yahoo.com/ \\"Yahoo Search\\") or
 [MSN](http://search.msn.com/ \\"MSN Search\\").
+
 \\\\end{CodeBlock}
 
 
@@ -18694,6 +19207,7 @@ _single underscores_
 **double asterisks**
 
 __double underscores__
+
 \\\\end{CodeBlock}
 
 
@@ -18710,6 +19224,7 @@ will produce:
 <strong>double asterisks</strong>
 
 <strong>double underscores</strong>
+
 \\\\end{CodeBlock}
 
 
@@ -18725,6 +19240,7 @@ Emphasis can be used in the middle of a word:
 
 \\\\begin{CodeBlock}{text}
 un*fucking*believable
+
 \\\\end{CodeBlock}
 
 
@@ -18742,6 +19258,7 @@ escape it:
 
 \\\\begin{CodeBlock}{text}
 \\\\*this text is surrounded by literal asterisks\\\\*
+
 \\\\end{CodeBlock}
 
 
@@ -18756,6 +19273,7 @@ normal paragraph. For example:
 
 \\\\begin{CodeBlock}{text}
 Use the \`printf()\` function.
+
 \\\\end{CodeBlock}
 
 
@@ -18766,6 +19284,7 @@ will produce:
 
 \\\\begin{CodeBlock}{text}
 <p>Use the <code>printf()</code> function.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -18777,6 +19296,7 @@ multiple backticks as the opening and closing delimiters:
 
 \\\\begin{CodeBlock}{text}
 \`\`There is a literal backtick (\`) here.\`\`
+
 \\\\end{CodeBlock}
 
 
@@ -18787,6 +19307,7 @@ which will produce this:
 
 \\\\begin{CodeBlock}{text}
 <p><code>There is a literal backtick (\`) here.</code></p>
+
 \\\\end{CodeBlock}
 
 
@@ -18801,6 +19322,7 @@ literal backtick characters at the beginning or end of a code span:
 A single backtick in a code span: \`\` \` \`\`
 
 A backtick-delimited string in a code span: \`\` \`foo\` \`\`
+
 \\\\end{CodeBlock}
 
 
@@ -18813,6 +19335,7 @@ will produce:
 <p>A single backtick in a code span: <code>\`</code></p>
 
 <p>A backtick-delimited string in a code span: <code>\`foo\`</code></p>
+
 \\\\end{CodeBlock}
 
 
@@ -18825,6 +19348,7 @@ tags. Markdown will turn this:
 
 \\\\begin{CodeBlock}{text}
 Please don't use any \`<blink>\` tags.
+
 \\\\end{CodeBlock}
 
 
@@ -18835,6 +19359,7 @@ into:
 
 \\\\begin{CodeBlock}{text}
 <p>Please don't use any <code>&lt;blink&gt;</code> tags.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -18845,6 +19370,7 @@ You can write this:
 
 \\\\begin{CodeBlock}{text}
 \`&#8212;\` is the decimal-encoded equivalent of \`&mdash;\`.
+
 \\\\end{CodeBlock}
 
 
@@ -18856,6 +19382,7 @@ to produce:
 \\\\begin{CodeBlock}{text}
 <p><code>&amp;#8212;</code> is the decimal-encoded
 equivalent of <code>&amp;mdash;</code>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -18880,6 +19407,7 @@ Inline image syntax looks like this:
 ![Alt text](/path/to/img.jpg)
 
 ![Alt text](/path/to/img.jpg \\"Optional title\\")
+
 \\\\end{CodeBlock}
 
 
@@ -18904,6 +19432,7 @@ Reference-style image syntax looks like this:
 
 \\\\begin{CodeBlock}{text}
 ![Alt text][id]
+
 \\\\end{CodeBlock}
 
 
@@ -18915,6 +19444,7 @@ are defined using syntax identical to link references:
 
 \\\\begin{CodeBlock}{text}
 [id]: url/to/image  \\"Optional title attribute\\"
+
 \\\\end{CodeBlock}
 
 
@@ -18939,6 +19469,7 @@ Markdown supports a shortcut style for creating \\"automatic\\" links for URLs a
 
 \\\\begin{CodeBlock}{text}
 <http://example.com/>
+
 \\\\end{CodeBlock}
 
 
@@ -18949,6 +19480,7 @@ Markdown will turn this into:
 
 \\\\begin{CodeBlock}{text}
 <a href=\\"http://example.com/\\">http://example.com/</a>
+
 \\\\end{CodeBlock}
 
 
@@ -18962,6 +19494,7 @@ spambots. For example, Markdown will turn this:
 
 \\\\begin{CodeBlock}{text}
 <address@example.com>
+
 \\\\end{CodeBlock}
 
 
@@ -18975,6 +19508,7 @@ into something like this:
 &#115;&#115;&#64;&#101;&#120;&#x61;&#109;&#x70;&#x6C;e&#x2E;&#99;&#111;
 &#109;\\">&#x61;&#x64;&#x64;&#x72;&#x65;&#115;&#115;&#64;&#101;&#120;&#x61;
 &#109;&#x70;&#x6C;e&#x2E;&#99;&#111;&#109;</a>
+
 \\\\end{CodeBlock}
 
 
@@ -19002,6 +19536,7 @@ before the asterisks, like this:
 
 \\\\begin{CodeBlock}{text}
 \\\\*literal asterisks\\\\*
+
 \\\\end{CodeBlock}
 
 
@@ -19019,10 +19554,11 @@ _   underscore
 []  square brackets
 ()  parentheses
 #   hash mark
-+	plus sign
--	minus sign (hyphen)
++   plus sign
+-   minus sign (hyphen)
 .   dot
 !   exclamation mark
+
 \\\\end{CodeBlock}
 
 "
@@ -19034,25 +19570,25 @@ exports[`toLaTeX: remark specs mixed-indentation: mixed-indentation 1`] = `
 
 \\\\begin{itemize}
 \\\\item Very long
-			paragraph
+paragraph
 \\\\end{itemize}
 
 
 \\\\begin{enumerate}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{enumerate}
 
 
 \\\\begin{itemize}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{itemize}
 
 
 \\\\begin{enumerate}
 \\\\item Very long
-	paragraph
+paragraph
 \\\\end{enumerate}
 "
 `;
@@ -19464,6 +20000,7 @@ Multiple paragraphs:
 \\\\begin{CodeBlock}{text}
 Item 2. graf two. The quick brown fox jumped over the lazy dog's
 back.
+
 \\\\end{CodeBlock}
 
 
@@ -19482,12 +20019,12 @@ exports[`toLaTeX: remark specs paragraphs-and-indentation: paragraphs-and-indent
 
 
 This is a paragraph
-    and this is further text
+and this is further text
 
 
 
 This is a paragraph
-   and this is further text
+and this is further text
 
 
 
@@ -19497,6 +20034,7 @@ This is a paragraph with some asterisks
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -19518,6 +20056,7 @@ This is a paragraph
 
 \\\\begin{CodeBlock}{text}
 and this is code
+
 \\\\end{CodeBlock}
 
 
@@ -19536,6 +20075,7 @@ This is a paragraph with some asterisks in a code block
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -19700,7 +20240,7 @@ Hyphen should be escaped at the beginning of a line:
 
 - not a list item
 - not a list item
-  + not a list item
++ not a list item
 
 
 
@@ -19717,7 +20257,7 @@ And hash signs:
 
 
 \\\\# not a heading
-  \\\\#\\\\# not a subheading
+\\\\#\\\\# not a subheading
 
 
 
@@ -19882,6 +20422,7 @@ Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
 
 \\\\begin{CodeBlock}{text}
 Test code
+
 \\\\end{CodeBlock}
 
 
@@ -20119,6 +20660,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -20128,7 +20670,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -20138,11 +20681,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}
 
 "
@@ -20163,6 +20707,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -20172,7 +20717,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -20182,11 +20728,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}
 
 "
@@ -20289,9 +20836,11 @@ exports[`toLaTeX: remark specs task-list: task-list 1`] = `
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
 Hello;
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -20308,9 +20857,11 @@ World;
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
 Hello;
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -20318,9 +20869,11 @@ World;
 \\\\begin{enumerate}
 \\\\item \\\\begin{CodeBlock}{text}
 Foo.
+
 \\\\end{CodeBlock}
 \\\\item \\\\begin{CodeBlock}{text}
 Bar.
+
 \\\\end{CodeBlock}
 \\\\end{enumerate}
 
@@ -20331,6 +20884,7 @@ Bar.
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
     Hello;
+
 \\\\end{CodeBlock}
 \\\\end{itemize}
 
@@ -20338,13 +20892,15 @@ Bar.
 \\\\begin{enumerate}
 \\\\item \\\\begin{CodeBlock}{text}
 World;
+
 \\\\end{CodeBlock}
 \\\\end{enumerate}
 
 
 \\\\begin{itemize}
 \\\\item \\\\begin{CodeBlock}{text}
-	Hello;
+    Hello;
+
 \\\\end{CodeBlock}
 \\\\item World.
 \\\\end{itemize}
@@ -20379,7 +20935,7 @@ World;
 
 
 \\\\begin{enumerate}
-\\\\item [ 
+\\\\item [
 ] World;
 \\\\item [		] Hello;
 \\\\item [ 	 ] World.
@@ -20595,8 +21151,8 @@ CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\ \\\\hline
 
 exports[`toLaTeX: remark specs toplevel-paragraphs: toplevel-paragraphs 1`] = `
 "hello world
-    how are you
-    how are you
+how are you
+how are you
 
 
 
@@ -20606,6 +21162,7 @@ hello world
 
 \\\\begin{CodeBlock}{text}
 how are you
+
 \\\\end{CodeBlock}
 
 

--- a/packages/rebber/package.json
+++ b/packages/rebber/package.json
@@ -31,8 +31,11 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "collapse-white-space": "^1.0.5",
+    "detab": "^2.0.2",
     "has": "^1.0.1",
     "mdast-util-definitions": "^1.2.3",
+    "trim-lines": "^1.1.2",
     "xtend": "^4.0.1"
   }
 }

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -1,5 +1,4 @@
-/* Expose. */
-module.exports = code
+const detab = require('detab')
 
 const defaultMacro = (content, lang) => {
   if (!lang) lang = 'text'
@@ -19,7 +18,8 @@ const defaultMacro = (content, lang) => {
 }
 
 /* Stringify a Blockquote `node`. */
-function code (ctx, node) {
+module.exports = function code (ctx, node) {
+  const value = node.value ? detab(`${node.value}\n`) : ''
   const macro = ctx.code || defaultMacro
-  return macro(node.value, node.lang)
+  return macro(value, node.lang)
 }

--- a/packages/rebber/src/types/inlinecode.js
+++ b/packages/rebber/src/types/inlinecode.js
@@ -1,10 +1,7 @@
-// TODO: make it customizable
-/* Expose. */
-module.exports = inlineCode
-
+const collapse = require('collapse-white-space')
 const escape = require('../escaper')
 
-function inlineCode (ctx, node) {
-  const finalCode = escape(node.value)
+module.exports = function inlineCode (ctx, node) {
+  const finalCode = escape(collapse(node.value))
   return `\\texttt{${finalCode}}`
 }

--- a/packages/rebber/src/types/text.js
+++ b/packages/rebber/src/types/text.js
@@ -1,12 +1,10 @@
 /* Dependencies. */
+const trimLines = require('trim-lines')
 const escaper = require('../escaper')
 
-/* Expose. */
-module.exports = text
-
 /* Stringify a text `node`. */
-function text (ctx, node, index, parent) {
-  const value = node.value
+module.exports = function text (ctx, node, index, parent) {
+  const value = trimLines(node.value)
 
   return isLiteral(parent) ? value : escaper(value, ctx.escapes)
 }

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -67,6 +67,7 @@ quote
 exports[`code 1`] = `
 "\\\\begin{CodeBlock}{python}
 print('bla')
+
 \\\\end{CodeBlock}
 
 
@@ -75,12 +76,14 @@ print('bla')
 print('bla')
 print('bla')
 print('bla')
+
 \\\\end{CodeBlock}
 
 
 
 \\\\begin{CodeBlock}{text}
 a code without lang
+
 \\\\end{CodeBlock}"
 `;
 
@@ -446,6 +449,7 @@ Code: Second
 
 \\\\begin{CodeBlock}{python}
 print('code without caption')
+
 \\\\end{CodeBlock}"
 `;
 
@@ -529,6 +533,7 @@ block & [] \\\\\\\\ \\\\hline
 \\\\footnote{\\\\label{appendix-1}}
 \\\\begin{CodeBlock}{python}
 print('bla')
+
 \\\\end{CodeBlock}"
 `;
 
@@ -641,6 +646,7 @@ Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR\\
 exports[`regression: code block without language 1`] = `
 "\\\\begin{CodeBlock}{text}
 a
+
 \\\\end{CodeBlock}"
 `;
 

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -85,6 +85,7 @@ Auto-links should not occur here: \\\\CodeInline{<http://example.com/>}
 
 \\\\begin{CodeBlock}{text}
 or here: <http://example.com/>
+
 \\\\end{CodeBlock}"
 `;
 
@@ -193,6 +194,7 @@ Bang: \\\\!
 Plus: \\\\+
 
 Minus: \\\\-
+
 \\\\end{CodeBlock}
 
 
@@ -272,6 +274,7 @@ Example:
 sub status {
     print \\"working\\";
 }
+
 \\\\end{CodeBlock}
 
 Or:
@@ -280,6 +283,7 @@ Or:
 sub status {
     return \\"working\\";
 }
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -290,6 +294,7 @@ exports[`#basic properly renders codeblock-in-list.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
   Some *code*
+
 \\\\end{CodeBlock}
 \\\\item Another list item
 
@@ -297,6 +302,7 @@ exports[`#basic properly renders codeblock-in-list.txt 1`] = `
   More code
 
   And more code
+
 \\\\end{CodeBlock}
 \\\\end{itemize}"
 `;
@@ -342,6 +348,7 @@ exports[`#basic properly renders horizontal-rules.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
 ---
+
 \\\\end{CodeBlock}
 
 
@@ -364,6 +371,7 @@ exports[`#basic properly renders horizontal-rules.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
 - - -
+
 \\\\end{CodeBlock}
 
 
@@ -390,6 +398,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -412,6 +421,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 * * *
+
 \\\\end{CodeBlock}
 
 
@@ -438,6 +448,7 @@ Underscores:
 
 \\\\begin{CodeBlock}{text}
 ___
+
 \\\\end{CodeBlock}
 
 
@@ -460,6 +471,7 @@ ___
 
 \\\\begin{CodeBlock}{text}
 _ _ _
+
 \\\\end{CodeBlock}"
 `;
 
@@ -521,8 +533,9 @@ This should be a code block, though:
 
 \\\\begin{CodeBlock}{text}
 <div>
-	foo
+    foo
 </div>
+
 \\\\end{CodeBlock}
 
 
@@ -533,6 +546,7 @@ As should this:
 
 \\\\begin{CodeBlock}{text}
 <div>foo</div>
+
 \\\\end{CodeBlock}
 
 
@@ -570,6 +584,7 @@ Code block:
 
 \\\\begin{CodeBlock}{text}
 <!-- Comment -->
+
 \\\\end{CodeBlock}
 
 
@@ -586,6 +601,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 <hr />
+
 \\\\end{CodeBlock}
 
 
@@ -678,6 +694,7 @@ Indented [four] times.
 
 \\\\begin{CodeBlock}{text}
 [four]: /url
+
 \\\\end{CodeBlock}
 
 
@@ -701,7 +718,7 @@ breaks\\\\ref{line breaks}
 
 
 
-and line 
+and line
 breaks\\\\ref{line breaks} with one space.
 
 
@@ -717,7 +734,7 @@ short ref\\\\ref{short ref}
 
 
 
-short 
+short
 ref\\\\ref{short ref}
 
 
@@ -974,6 +991,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -983,7 +1001,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -993,11 +1012,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2035,6 +2055,7 @@ First Header | Second Header
 ------------ | -------------
 Content Cell | Content Cell
 Content Cell | Content Cell
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2084,6 +2105,7 @@ exports[`#extensions properly renders fenced_code.txt 1`] = `
 +     return _wrap_diff(CONTEXT_DIFF_HEADER_PATTERN,
 +                       CONTEXT_DIFF_LINE_PATTERN,
 +\`\`\`
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2123,6 +2145,7 @@ exports[`#extensions properly renders github_flavored.txt 1`] = `
 +     return _wrap_diff(CONTEXT_DIFF_HEADER_PATTERN,
 +                       CONTEXT_DIFF_LINE_PATTERN,
 +\`\`\`
+
 \\\\end{CodeBlock}
 
 
@@ -2138,6 +2161,7 @@ Test support for foo+bar lexer names.
   <li><a href=\\"{{ user.url }}\\">{{ user.username }}</a></li>
 {% endfor %}
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -2156,6 +2180,7 @@ Test support for foo+bar lexer names in citation.
 {% endfor %}
 
 </ul>
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}
 
@@ -2174,6 +2199,7 @@ Test support for foo+bar lexer names with hightlight.
 {% endfor %}
 
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -2191,6 +2217,7 @@ Test support for foo+bar lexer names with linenostart.
 {% endfor %}
 
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -2206,6 +2233,7 @@ Test support for foo+bar lexer names with both.
   <li><a href=\\"{{ user.url }}\\">{{ user.username }}</a></li>
 {% endfor %}
 </ul>
+
 \\\\end{CodeBlock}
 
 
@@ -2227,6 +2255,7 @@ Code into paragraph
 </ul>
 \`\`\`
 with end
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2288,6 +2317,7 @@ exports[`#misc properly renders arabic.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
 print \\"Hello World!\\"
+
 \\\\end{CodeBlock}
 
 
@@ -2309,6 +2339,7 @@ else:
   x = x-1
 
  print num
+
 \\\\end{CodeBlock}
 
 
@@ -2363,6 +2394,7 @@ six tabbed lines
 
 
 End of tabbed block
+
 \\\\end{CodeBlock}
 
 
@@ -2400,6 +2432,7 @@ six blank lines
 
 
 End of block
+
 \\\\end{CodeBlock}
 
 
@@ -2520,6 +2553,7 @@ blah
 
 \\\\begin{CodeBlock}{text}
 > this one had four so it's a code block.
+
 \\\\end{CodeBlock}
 
 
@@ -2581,6 +2615,7 @@ Some of these words <em>are emphasized also</em>.</p>
 
 <p>Use two asterisks for <strong>strong emphasis</strong>.
 Or, if you prefer, <strong>use two underscores instead</strong>.</p>
+
 \\\\end{CodeBlock}
 
 
@@ -2656,6 +2691,7 @@ xxx xxx xxx xxx xxx xxx xxx xxx"
 exports[`#misc properly renders code-first-line.txt 1`] = `
 "\\\\begin{CodeBlock}{text}
 print \\"This is a code block.\\"
+
 \\\\end{CodeBlock}"
 `;
 
@@ -2759,7 +2795,7 @@ great folks} - This \\\\textit{does} work as expected."
 `;
 
 exports[`#misc properly renders email.txt 1`] = `
-"asdfasdfadsfasd \\\\externalLink{yuri@freewisdom.org}{mailto:yuri@freewisdom.org} or you can say 
+"asdfasdfadsfasd \\\\externalLink{yuri@freewisdom.org}{mailto:yuri@freewisdom.org} or you can say
 instead \\\\externalLink{yuri@freewisdom.org}{mailto:yuri@freewisdom.org}
 
 
@@ -2842,7 +2878,7 @@ exports[`#misc properly renders link-with-parenthesis.txt 1`] = `"\\\\externalLi
 
 exports[`#misc properly renders lists.txt 1`] = `
 "\\\\begin{itemize}
-\\\\item A multi-paragraph list, 
+\\\\item A multi-paragraph list,
 unindented.
 \\\\end{itemize}
 
@@ -2901,8 +2937,8 @@ asda asdf asdfasd
 exports[`#misc properly renders lists3.txt 1`] = `
 "\\\\begin{itemize}
 \\\\item blah blah blah
-  sdf asdf asdf asdf asdf
-  asda asdf asdfasd
+sdf asdf asdf asdf asdf
+asda asdf asdfasd
 \\\\end{itemize}"
 `;
 
@@ -3199,6 +3235,7 @@ on three lines."
 exports[`#php properly renders Code block on second line.txt 1`] = `
 "\\\\begin{CodeBlock}{text}
 Codeblock on second line
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3364,6 +3401,7 @@ Auto-links should not occur here: \\\\CodeInline{<http://example.com/>}
 
 \\\\begin{CodeBlock}{text}
 or here: <http://example.com/>
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3375,6 +3413,7 @@ Example:
 sub status {
     print \\"working\\";
 }
+
 \\\\end{CodeBlock}
 
 Or:
@@ -3383,6 +3422,7 @@ Or:
 sub status {
     return \\"working\\";
 }
+
 \\\\end{CodeBlock}
 \\\\end{Quotation}"
 `;
@@ -3410,6 +3450,7 @@ exports[`#pl #Tests_2007 properly renders Horizontal rules.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
 ---
+
 \\\\end{CodeBlock}
 
 
@@ -3432,6 +3473,7 @@ exports[`#pl #Tests_2007 properly renders Horizontal rules.txt 1`] = `
 
 \\\\begin{CodeBlock}{text}
 - - -
+
 \\\\end{CodeBlock}
 
 
@@ -3458,6 +3500,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 ***
+
 \\\\end{CodeBlock}
 
 
@@ -3480,6 +3523,7 @@ Asterisks:
 
 \\\\begin{CodeBlock}{text}
 * * *
+
 \\\\end{CodeBlock}
 
 
@@ -3506,6 +3550,7 @@ Underscores:
 
 \\\\begin{CodeBlock}{text}
 ___
+
 \\\\end{CodeBlock}
 
 
@@ -3528,6 +3573,7 @@ ___
 
 \\\\begin{CodeBlock}{text}
 _ _ _
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3563,7 +3609,7 @@ break\\\\ref{line break}.
 
 
 
-This one has a line 
+This one has a line
 break\\\\ref{line break} with a line-ending space.
 
 
@@ -3818,6 +3864,7 @@ Code:
 
 \\\\begin{CodeBlock}{text}
 this code block is indented by one tab
+
 \\\\end{CodeBlock}
 
 
@@ -3827,7 +3874,8 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-	this code block is indented by two tabs
+    this code block is indented by two tabs
+
 \\\\end{CodeBlock}
 
 
@@ -3837,11 +3885,12 @@ And:
 
 
 \\\\begin{CodeBlock}{text}
-+	this is an example list item
-	indented with tabs
++   this is an example list item
+    indented with tabs
 
 +   this is an example list item
     indented with spaces
+
 \\\\end{CodeBlock}"
 `;
 
@@ -3969,6 +4018,7 @@ Balbla
 
 \\\\begin{CodeBlock}{text}
 Blabla<--COMMENTS hahaha COMMENTS-->Balbla
+
 \\\\end{CodeBlock}
 
 


### PR DESCRIPTION
* use `collapse-white-space` for inline-code
* use `detab` for code
* use `trim-lines` for text

cf. https://github.com/syntax-tree/mdast-util-to-hast/

fixes the \n bug detected in #342

The generated latex shouldn't impact the way PDF look but please check anyway!