### PR TITLE
Allow varying width table

### DIFF
--- a/packages/remark-grid-tables/__tests__/index.js
+++ b/packages/remark-grid-tables/__tests__/index.js
@@ -200,38 +200,28 @@ test('regression: handles east asian ambiguous width', () => {
   expect(test4).toBe(base.replace('ï', '¯'))
 })
 
-test('handles various character widths', () => {
-  // these should "look ok" in monospace fonts
-  const {contents: test1a} = render(dedent`
-    +----+
-    | 👨‍👨‍👧‍👦 |
-    +----+
+test('distinguish between tables of the same width', () => {
+  const {contents: test1} = render(dedent`
+    +---+---+---+
+    | 1 | 2 | 3 |
+    +---+---+---+
+    |   | a     |
+    +---+---+---+
+    |     b |   |
+    +-------+---+
   `)
 
-  const {contents: test2a} = render(dedent`
-    +----+
-    | 🌵 |
-    +----+
+  const {contents: test2} = render(dedent`
+    +---+---+---+
+    | 1 | 2 | 3 |
+    +---+---+---+
+    |   | a     |
+    +---+-------+
+    | b |       |
+    +---+-------+
   `)
 
-  // these should not look ok in monospace fonts, it should be
-  // visible that the top and bottom lines (`+---+`) are 1 dash too short
-  const {contents: test1b} = render(dedent`
-    +---+
-    | 👨‍👨‍👧‍👦 |
-    +---+
-  `)
-
-  const {contents: test2b} = render(dedent`
-    +---+
-    | 🌵 |
-    +---+
-  `)
-
-  expect(test1a).toContain('<table>')
-  expect(test1b).not.toContain('<table>')
-  expect(test2a).toContain('<table>')
-  expect(test2b).not.toContain('<table>')
+  expect(test1).not.toEqual(test2)
 })
 
 test('handles Cyrillic script', () => {

--- a/packages/remark-grid-tables/dist/index.js
+++ b/packages/remark-grid-tables/dist/index.js
@@ -382,17 +382,15 @@ function extractTable(value, eat, tokenizer) {
   }); // Extract table
 
   if (!possibleGridTable[i + 1]) return [null, null, null, null];
-  var lineLength = stringWidth(possibleGridTable[i + 1]);
   var gridTable = [];
   var realGridTable = [];
   var hasHeader = false;
 
   for (; i < possibleGridTable.length; i++) {
     var _line = possibleGridTable[i];
-    var realLine = markdownLines[i];
-    var isMainLine = totalMainLineRegex.exec(_line); // line is in table
+    var realLine = markdownLines[i]; // line is in table
 
-    if (isMainLine && stringWidth(_line) === lineLength) {
+    if (totalMainLineRegex.exec(_line)) {
       var _isHeaderLine = headerLineRegex.exec(_line);
 
       if (_isHeaderLine && !hasHeader) hasHeader = true; // A table can't have 2 headers

--- a/packages/remark-grid-tables/src/index.js
+++ b/packages/remark-grid-tables/src/index.js
@@ -293,16 +293,15 @@ function extractTable (value, eat, tokenizer) {
 
   // Extract table
   if (!possibleGridTable[i + 1]) return [null, null, null, null]
-  const lineLength = stringWidth(possibleGridTable[i + 1])
+
   const gridTable = []
   const realGridTable = []
   let hasHeader = false
   for (; i < possibleGridTable.length; i++) {
     const line = possibleGridTable[i]
     const realLine = markdownLines[i]
-    const isMainLine = totalMainLineRegex.exec(line)
     // line is in table
-    if (isMainLine && stringWidth(line) === lineLength) {
+    if (totalMainLineRegex.exec(line)) {
       const isHeaderLine = headerLineRegex.exec(line)
       if (isHeaderLine && !hasHeader) hasHeader = true
       // A table can't have 2 headers


### PR DESCRIPTION
Solves issue #369 by removing global length limit on tables; a test was modified: it was used to check that varying-width tables were not allowed, and was replaced by a test checking that two tables that could look alike are well dinstinguinshed by the software.