### PR TITLE
Add mhchem extension to KaTeX (solves #359)

### DIFF
--- a/packages/zmarkdown/__tests__/latex.tests.js
+++ b/packages/zmarkdown/__tests__/latex.tests.js
@@ -193,3 +193,10 @@ test('regression: code block without language', () => {
 
   return expect(p).resolves.toMatchSnapshot()
 })
+
+test('properly loads extensions - mhchem', () => {
+  const markdown = '$\\ce{H2O}$'
+  const result = renderString()(markdown)
+
+  return expect(result).resolves.toContain(markdown)
+})

--- a/packages/zmarkdown/__tests__/new-html-suite.test.js
+++ b/packages/zmarkdown/__tests__/new-html-suite.test.js
@@ -89,9 +89,9 @@ describe('math', () => {
   it('properly loads extensions - mhchem', async () => {
     const markdown = '$\\ce{H2O}$'
     const result = await renderVfile(markdown)
-    const errorMsg = result.messages[0]
 
-    expect(errorMsg).toBeUndefined()
+    expect(result.messages).toEqual([])
+    expect(result.contents).toContain('<span class="mord mathrm">H</span>')
   })
 })
 

--- a/packages/zmarkdown/__tests__/new-html-suite.test.js
+++ b/packages/zmarkdown/__tests__/new-html-suite.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 const clone = require('clone')
 const dedent = require('dedent')
 
@@ -10,12 +9,11 @@ remarkConfig.ping.pingUsername = () => false
 
 const zmarkdown = require('../server')
 
-const renderString = (config = {remarkConfig, rebberConfig}) => {
+const renderVfile = (config = {remarkConfig, rebberConfig}) => {
   let configToUse = config
 
   const renderWithConfig = (input) =>
-    zmarkdown(configToUse).renderString(input).then((vfile) =>
-      vfile.toString().trim())
+    zmarkdown(configToUse).renderString(input)
 
   if (typeof config === 'string') {
     const input = config
@@ -25,9 +23,10 @@ const renderString = (config = {remarkConfig, rebberConfig}) => {
   return renderWithConfig
 }
 
-const renderFile = (config = {remarkConfig, rebberConfig}) =>
-  (input) =>
-    zmarkdown(config).renderFile(input).then((vfile) => vfile.toString())
+const renderString = (config = {remarkConfig, rebberConfig}) => {
+  return renderVfile(config).then((vfile) =>
+    vfile.toString().trim())
+}
 
 /* jest */
 const HtmlDiffer = require('html-differ').HtmlDiffer
@@ -69,7 +68,6 @@ describe('math', () => {
     expect(renderString(markdown)).resolves.not.toMatch('inlineMath')
   })
 
-
   it('must not parse a raw starting dollar', () => {
     const markdown = '`$`\\alpha$'
 
@@ -87,6 +85,14 @@ describe('math', () => {
 
     expect(renderString(markdown)).resolves.not.toMatch('<pre')
   })
+
+  it('properly loads extensions - mhchem', async () => {
+    const markdown = '$\\ce{H2O}$'
+    const result = await renderVfile(markdown)
+    const errorMsg = result.messages[0]
+
+    expect(errorMsg).toBeUndefined()
+  })
 })
 
 describe('pedantic', () => {
@@ -100,7 +106,6 @@ describe('pedantic', () => {
 const maxNesting = remarkConfig.maxNesting
 describe('depth checks', () => {
   it(`is fast enough with ${maxNesting} nested quotes`, () => {
-    const fs = require('fs')
     const base = ['foo', '\n']
     const input = Array.from({length: maxNesting}).reduce((acc, _, i) => {
       return acc + base.map((x, j) => ('>'.repeat(i) + ((i && !j && ' ') || '') + x)).join('\n')
@@ -117,7 +122,6 @@ describe('depth checks', () => {
   })
 
   it(`fails with > ${maxNesting} nested quotes`, () => {
-    const fs = require('fs')
     const base = ['foo', '\n']
     const input = Array.from({length: maxNesting + 1}).reduce((acc, _, i) => {
       return acc + base.map((x, j) => ('>'.repeat(i) + ((i && !j && ' ') || '') + x)).join('\n')

--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -39,10 +39,12 @@ const rehypeLineNumbers = require('./utils/rehype-line-numbers')
 const rehypePostfixFootnotes = require('rehype-postfix-footnote-anchors')
 const rehypeSlug = require('rehype-slug')
 const rehypeSanitize = require('rehype-sanitize')
-
 const rehypeStringify = require('rehype-stringify')
 
 const remarkConfig = require('./config/remark')
+
+// KaTeX uses globals: load the mhchem extension
+require('katex/dist/contrib/mhchem')
 
 const jsFiddleAndInaFilter = node => {
   if (node.properties.src) {


### PR DESCRIPTION
Add the mhchem extension by using KaTeX globals; also adds to tests to make sure:

1. it is well rendered by KaTeX (avoid version conflicts): the test detects the lack of "KaTeX parse error: Undefined control sequence" message;
2. it is directly used without modifications in rebber (which may be overkill, because it is basically math).