### PR TITLE
rebber-plugins/zmarkdown: Improve grid table latex rendering

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -781,27 +781,24 @@ exports[`mix-3 1`] = `
 
 
 
-\\\\begin{flushright}
+{\\\\raggedleft
 \\\\begin{itemize}
 \\\\item item
 \\\\item item
 \\\\end{itemize}
-
-\\\\end{flushright}
+}
 
 
 \\\\part{centered list}
 
 
 
-\\\\begin{center}
-\\\\begin{itemize}
+{\\\\centering \\\\begin{itemize}
 \\\\item item
 \\\\item item
 \\\\item item
 \\\\end{itemize}
-
-\\\\end{center}
+}
 
 
 \\\\part{left list}

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -292,14 +292,14 @@ a paragraph\\\\footnote[l9c12o138]{\\\\label{footnote:l9c12o138} footnoteRawPar 
 `;
 
 exports[`gridTable 1`] = `
-"\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & ABBR \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{ABBR   spanning} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{ABBR   spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 \\\\captionof{table}{The new table ABBR [\\\\textasciicircum{}foot] with ||CTRL|| + ||S||}
 
@@ -313,7 +313,7 @@ multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
@@ -321,105 +321,105 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-inline & \\\\texttt{inline} br \\\\par \\\\texttt{inline} \\\\\\\\ \\\\hline
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{E} &  \\\\\\\\ \\\\cline{2-4}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
 \\\\rowfont[l]{}
- & F & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{G} \\\\\\\\ \\\\hline
-a & b & \\\\multirow{2}{*}{c   d \\\\par  \\\\par g} \\\\\\\\ \\\\cline{1-2}
+ & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
+a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
 e & f &  &  \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{Table Headings} & Here \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{column[\\\\textasciicircum{}foot]} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column[\\\\textasciicircum{}foot]}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{A} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{B} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\hline
+ & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{E} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{F} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{G} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{A} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{B} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{C} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-H & \\\\multicolumn{16}{|p{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{} & He \\\\\\\\ \\\\hline
+H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
+Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
 Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
 K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
 Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
 Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|p{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|p{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Lanthanide} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Actinide} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
+Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -429,7 +429,7 @@ Text at the end
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -439,9 +439,9 @@ Text at the
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-a & \\\\multirow{2}{*}{} &  \\\\\\\\ \\\\cline{1-1}
+a & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} &  \\\\\\\\ \\\\cline{1-1}
 \\\\rowfont[l]{}
 b &  &  & c \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -449,11 +449,11 @@ b &  &  & c \\\\\\\\ \\\\hline
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 5}|p{\\\\dimexpr(\\\\linewidth) / 5}|p{\\\\dimexpr(\\\\linewidth) / 5}|p{\\\\dimexpr(\\\\linewidth) / 5}|p{\\\\dimexpr(\\\\linewidth) / 5}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{span} & header & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{span} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span}} & header & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span}} \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-elem & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{span middle} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{} \\\\\\\\ \\\\hline
+elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span middle}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -814,14 +814,14 @@ exports[`mix-3 1`] = `
 `;
 
 exports[`mix-4 1`] = `
-"\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{column spanning} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 \\\\captionof{table}{The new table \\\\abbr{ABBR}{abbreviation} \\\\textsuperscript{\\\\ref{footnote:foot}} with \\\\keys{CTRL} + \\\\keys{S}}
 
@@ -829,7 +829,7 @@ multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\
 
 \\\\footnotetext[foot]{\\\\label{footnote:foot} a foot}
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
@@ -837,105 +837,105 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-inline & \\\\texttt{inline} br \\\\par \\\\texttt{inline} \\\\\\\\ \\\\hline
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{E} &  \\\\\\\\ \\\\cline{2-4}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
 \\\\rowfont[l]{}
- & F & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{G} \\\\\\\\ \\\\hline
-a & b & \\\\multirow{2}{*}{c   d \\\\par  \\\\par g} \\\\\\\\ \\\\cline{1-2}
+ & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
+a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
 e & f &  &  \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{Table Headings} & Here \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{column spanning} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{A} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{B} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\hline
+ & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{E} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{F} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{G} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{A} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{B} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{C} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-H & \\\\multicolumn{16}{|p{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{} & He \\\\\\\\ \\\\hline
+H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
+Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
 Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
 K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
 Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
 Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|p{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|p{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Lanthanide} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Actinide} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
+Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -945,7 +945,7 @@ Text at the end
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -955,9 +955,9 @@ Text at the
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-a & \\\\multirow{2}{*}{} &  \\\\\\\\ \\\\cline{1-1}
+a & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} &  \\\\\\\\ \\\\cline{1-1}
 \\\\rowfont[l]{}
 b &  &  & c \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -996,11 +996,11 @@ no caption"
 `;
 
 exports[`mix-7 1`] = `
-"\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{[]} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{[]}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 

--- a/packages/rebber-plugins/dist/type/align.js
+++ b/packages/rebber-plugins/dist/type/align.js
@@ -11,10 +11,10 @@ var defaultMacros = {
     return "\n\n".concat(innerText, "\n\n");
   },
   centerAligned: function centerAligned(innerText) {
-    return "\n\\begin{center}\n".concat(innerText, "\n\\end{center}\n");
+    return "\n{\\centering ".concat(innerText, "}\n");
   },
   rightAligned: function rightAligned(innerText) {
-    return "\n\\begin{flushright}\n".concat(innerText, "\n\\end{flushright}\n");
+    return "\n{\\raggedleft\n".concat(innerText, "}\n");
   },
   defaultType: function defaultType(innerText, type) {
     return "\n\\begin{".concat(type, "}\n").concat(innerText, "\n\\end{").concat(type, "}\n");

--- a/packages/rebber-plugins/dist/type/gridTable.js
+++ b/packages/rebber-plugins/dist/type/gridTable.js
@@ -79,32 +79,32 @@ function () {
     value: function gridTableCell(ctx, node) {
       var overriddenCtx = clone(ctx);
       this.colIndex++;
-      overriddenCtx.tableCell = undefined; // we have to replace \n by \par only in text node, not in other
+      overriddenCtx.tableCell = undefined; // we have to replace \n by \endgraf only in text node, not in other
       // see #352
 
       overriddenCtx.overrides.text = function (c, n, index, parent) {
-        return text(c, n, index, parent).replace(/\n/g, ' \\par ');
+        return text(c, n, index, parent).replace(/\n/g, ' \\endgraf ');
       };
 
       overriddenCtx.overrides.paragraph = function (c, n) {
-        return "".concat(paragraph(c, n).trim(), " \\par  \\par ");
+        return "".concat(paragraph(c, n).trim(), " \\endgraf \\endgraf ");
       };
 
       var baseText = tableCell(overriddenCtx, node).trim();
 
-      while (baseText.substring(baseText.length - '\\par'.length) === '\\par') {
-        baseText = baseText.substring(0, baseText.length - '\\par'.length).trim();
+      while (baseText.substring(baseText.length - '\\endgraf'.length) === '\\endgraf') {
+        baseText = baseText.substring(0, baseText.length - '\\endgraf'.length).trim();
       }
 
       if (node.data && node.data.hProperties.rowspan > 1) {
         this.currentSpan = node.data.hProperties.rowspan;
         this.multiLineCellIndex = this.colIndex;
-        baseText = "\\multirow{".concat(node.data.hProperties.rowspan, "}{*}{").concat(baseText, "}");
+        baseText = "\\multirow{".concat(this.currentSpan, "}{*}{\\parbox{\\linewidth}{").concat(baseText, "}}");
         this.colspan = node.data.hProperties.colspan > 1 ? node.data.hProperties.colspan : 1;
       } else if (node.data && node.data.hProperties.colspan > 1) {
         var colspan = node.data.hProperties.colspan;
-        var colDim = "p{\\dimexpr(\\linewidth) * ".concat(colspan, " / \\number-of-column}");
-        baseText = "\\multicolumn{".concat(colspan, "}{|").concat(colDim, "|}{").concat(baseText, "}");
+        var colDim = "m{\\dimexpr(\\linewidth) * ".concat(colspan, " / \\number-of-column}");
+        baseText = "\\multicolumn{".concat(colspan, "}{|").concat(colDim, "|}{\\parbox{\\linewidth}{").concat(baseText, "}}");
       }
 
       if (node.data && node.data.hProperties.colspan > 1) {
@@ -186,7 +186,7 @@ function () {
   }, {
     key: "gridTableHeaderParse",
     value: function gridTableHeaderParse() {
-      var headers = "|p{\\dimexpr(\\linewidth) / ".concat(this.nbOfColumns, "}").repeat(this.nbOfColumns);
+      var headers = "|m{\\dimexpr(\\linewidth) / ".concat(this.nbOfColumns, "}").repeat(this.nbOfColumns);
       return "".concat(headers, "|");
     }
   }, {
@@ -205,7 +205,7 @@ function gridTable(ctx, node) {
   var stringifier = new GridTableStringifier();
 
   overriddenCtx["break"] = function () {
-    return ' \\par';
+    return ' \\endgraf';
   }; // in gridtables '\\\\' won't work
 
 

--- a/packages/rebber-plugins/src/type/align.js
+++ b/packages/rebber-plugins/src/type/align.js
@@ -6,8 +6,8 @@ module.exports = align
 
 const defaultMacros = {
   leftAligned: (innerText) => `\n\n${innerText}\n\n`,
-  centerAligned: (innerText) => `\n\\begin{center}\n${innerText}\n\\end{center}\n`,
-  rightAligned: (innerText) => `\n\\begin{flushright}\n${innerText}\n\\end{flushright}\n`,
+  centerAligned: (innerText) => `\n{\\centering ${innerText}}\n`,
+  rightAligned: (innerText) => `\n{\\raggedleft\n${innerText}}\n`,
   defaultType: (innerText, type) => `\n\\begin{${type}}\n${innerText}\n\\end{${type}}\n`,
 }
 

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -462,27 +462,24 @@ exports[`mix-3 1`] = `
 
 
 
-\\\\begin{flushright}
+{\\\\raggedleft
 \\\\begin{itemize}
 \\\\item item
 \\\\item item
 \\\\end{itemize}
-
-\\\\end{flushright}
+}
 
 
 \\\\levelOneTitle{centered list}
 
 
 
-\\\\begin{center}
-\\\\begin{itemize}
+{\\\\centering \\\\begin{itemize}
 \\\\item item
 \\\\item item
 \\\\item item
 \\\\end{itemize}
-
-\\\\end{center}
+}
 
 
 \\\\levelOneTitle{left list}

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -495,14 +495,14 @@ exports[`mix-3 1`] = `
 `;
 
 exports[`mix-4 1`] = `
-"\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{column spanning} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 \\\\captionof{table}{The new table \\\\abbr{ABBR}{abbreviation} \\\\textsuperscript{\\\\ref{footnote:1}} with \\\\keys{CTRL} + \\\\keys{S}}
 
@@ -510,7 +510,7 @@ multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\
 
 \\\\footnotetext[1]{\\\\label{footnote:1} a foot}
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
@@ -518,11 +518,11 @@ space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 2}|p{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-inline & \\\\CodeInline{inline} br \\\\par \\\\CodeInline{inline} \\\\\\\\ \\\\hline
+inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -3881,11 +3881,9 @@ exports[`#zds #extensions properly renders align.txt 1`] = `
 
 
 
-\\\\begin{center}
-A centered paragraph
+{\\\\centering A centered paragraph
 
-
-\\\\end{center}
+}
 
 
 a simple paragraph
@@ -3893,11 +3891,10 @@ a simple paragraph
 
 
 
-\\\\begin{flushright}
+{\\\\raggedleft
 A right aligned paragraph
 
-
-\\\\end{flushright}
+}
 
 
 an other simple paragraph
@@ -3909,11 +3906,9 @@ A simple paragraph
 
 
 
-\\\\begin{center}
-A centered paragraph
+{\\\\centering A centered paragraph
 
-
-\\\\end{center}
+}
 
 
 a simple paragraph
@@ -3921,11 +3916,10 @@ a simple paragraph
 
 
 
-\\\\begin{flushright}
+{\\\\raggedleft
 A right aligned paragraph
 
-
-\\\\end{flushright}
+}
 
 
 an other simple paragraph
@@ -3933,13 +3927,11 @@ an other simple paragraph
 
 
 
-\\\\begin{center}
-A centered paragraph.
+{\\\\centering A centered paragraph.
 
 Containing two paragraph
 
-
-\\\\end{center}
+}
 
 
 an other simple paragraph
@@ -3947,13 +3939,11 @@ an other simple paragraph
 
 
 
-\\\\begin{center}
-A right aligned paragraph.
+{\\\\centering A right aligned paragraph.
 
 Containing two paragraph
 
-
-\\\\end{center}
+}
 
 
 an other simple paragraph
@@ -3961,13 +3951,11 @@ an other simple paragraph
 
 
 
-\\\\begin{center}
-A centered paragraph.
+{\\\\centering A centered paragraph.
 
 An other centered paragraph.
 
-
-\\\\end{center}
+}
 
 
 a simple paragraph

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -4143,105 +4143,105 @@ exports[`#zds #extensions properly renders grid_tables.txt 1`] = `
 \\\\levelTwoTitle{Basic example}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{Table Headings} & Here \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{cell \\\\par spans \\\\par rows} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{column spanning} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & normal & cell \\\\\\\\ \\\\hline
-multi \\\\par line \\\\par  \\\\par cells \\\\par too & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{cells can be \\\\par \\\\textit{formatted} \\\\par \\\\textbf{paragraphs}} \\\\\\\\ \\\\hline
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{D} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{A} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{B} \\\\\\\\ \\\\cline{2-3}
+\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
  & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{E} \\\\\\\\ \\\\hline
+ & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 3}|}{A} \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 3}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multirow{2}{*}{B} & C & \\\\multirow{2}{*}{D} \\\\\\\\ \\\\cline{1-2}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & C & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} \\\\\\\\ \\\\cline{1-2}
 E &  \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{4}{*}{C} & \\\\multirow{2}{*}{D} & E \\\\\\\\ \\\\cline{1-1}
+\\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & E \\\\\\\\ \\\\cline{1-1}
 \\\\rowfont[l]{}
 F &  \\\\\\\\ \\\\hline
-\\\\multirow{2}{*}{G} & H \\\\\\\\ \\\\cline{2-2}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{G}} & H \\\\\\\\ \\\\cline{2-2}
  & I \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|p{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-A & \\\\multirow{2}{*}{B} & \\\\multirow{4}{*}{C} \\\\\\\\ \\\\cline{1-2}
+A & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\cline{1-2}
 \\\\rowfont[l]{}
 D &  \\\\\\\\ \\\\cline{1-2}
-E & \\\\multirow{2}{*}{F} &  \\\\\\\\ \\\\cline{1-2}
+E & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{F}} &  \\\\\\\\ \\\\cline{1-2}
 G &  \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{E} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{F} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{G} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{A} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{B} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{C} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{A} & \\\\multirow{2}{*}{B} & C & D & \\\\multirow{2}{*}{E} & \\\\multirow{3}{*}{F} \\\\\\\\ \\\\cline{1-5}
+\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & C & D & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{E}} & \\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\cline{1-5}
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{G} &  \\\\\\\\ \\\\cline{1-5}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 6}|}{H} &  \\\\\\\\ \\\\hline
-\\\\multicolumn{6}{|p{\\\\dimexpr(\\\\linewidth) * 6 / 6}|}{I} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{\\\\parbox{\\\\linewidth}{G}} &  \\\\\\\\ \\\\cline{1-5}
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 6}|}{\\\\parbox{\\\\linewidth}{H}} &  \\\\\\\\ \\\\hline
+\\\\multicolumn{6}{|m{\\\\dimexpr(\\\\linewidth) * 6 / 6}|}{\\\\parbox{\\\\linewidth}{I}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|p{\\\\dimexpr(\\\\linewidth) / 7}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-A & \\\\multicolumn{6}{|p{\\\\dimexpr(\\\\linewidth) * 6 / 7}|}{B} \\\\\\\\ \\\\hline
+A & \\\\multicolumn{6}{|m{\\\\dimexpr(\\\\linewidth) * 6 / 7}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{4}{*}{C} & \\\\multirow{4}{*}{\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\cline{1-1}
+\\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} & \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\cline{1-1}
 \\\\rowfont[c]{\\\\bfseries}
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{H} \\\\\\\\ \\\\hline
-\\\\end{longtabu}} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{H}} \\\\\\\\ \\\\hline
+\\\\end{longtabu}}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
  &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
  &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
@@ -4249,23 +4249,23 @@ D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|p{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|m{\\\\dimexpr(\\\\linewidth) / 18}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-H & \\\\multicolumn{16}{|p{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{} & He \\\\\\\\ \\\\hline
+H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
+Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
 Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
 K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
 Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
 Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|p{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|p{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Lanthanide} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{Actinide} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
+Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
+\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -4275,7 +4275,7 @@ Text at the end
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -4292,38 +4292,38 @@ In this examples, the second row should always be a full-cell
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{A} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{B | C} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
-A & \\\\multicolumn{3}{|p{\\\\dimexpr(\\\\linewidth) * 3 / 4}|}{} \\\\\\\\ \\\\hline
+A & \\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 4}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{B | C} \\\\\\\\ \\\\hline
-\\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{D   E} & F & G \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{D   E}} & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{B | C} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|p{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{4}{|p{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{B  | C} \\\\\\\\ \\\\hline
+\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{B  | C}} \\\\\\\\ \\\\hline
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -4359,7 +4359,7 @@ D & E & F & G \\\\\\\\ \\\\hline
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
  \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -4369,9 +4369,9 @@ Bug \\\\#107
 
 
 
-\\\\begin{longtabu}{|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|p{\\\\dimexpr(\\\\linewidth) / 6}|} \\\\hline
+\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
- & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{case1} & \\\\multicolumn{2}{|p{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{case2} & case3 \\\\\\\\ \\\\hline
+ & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{\\\\parbox{\\\\linewidth}{case1}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{\\\\parbox{\\\\linewidth}{case2}} & case3 \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
  & case4 & case5 & case6 & case7 &  \\\\\\\\ \\\\hline
 \\\\rowfont[c]{\\\\bfseries}


### PR DESCRIPTION
fix #374 

- uses the "switch command" version of centering and flushright https://cs.overleaf.com/learn/latex/Text_alignment#Right-justified_text
- use parbox instead of nothing in multirow and multicol
- uses `m{dim}` instead of `p{dim}`
- uses  `\endgraph` insteand of `\par` to embody line-break char
