### PR TITLE
rebber-plugins/zmarkdown : fix row font handling

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -295,9 +295,8 @@ exports[`gridTable 1`] = `
 "\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & ABBR \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{ABBR   spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{ABBR   spanning}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -316,7 +315,7 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -324,9 +323,8 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -334,9 +332,8 @@ block & [] \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -344,9 +341,8 @@ A & B & C \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
  & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
 a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
 e & f &  &  \\\\\\\\ \\\\hline
@@ -356,11 +352,9 @@ e & f &  &  \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column[\\\\textasciicircum{}foot]}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column[\\\\textasciicircum{}foot]}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -369,9 +363,8 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -452,7 +445,7 @@ b &  &  & c \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|m{\\\\dimexpr(\\\\linewidth) / 5}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span}} & header & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span}} \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{span middle}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -817,9 +810,8 @@ exports[`mix-4 1`] = `
 "\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -832,7 +824,7 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -840,9 +832,8 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -850,9 +841,8 @@ block & [] \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -860,9 +850,8 @@ A & B & C \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
  & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
 a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
 e & f &  &  \\\\\\\\ \\\\hline
@@ -872,11 +861,9 @@ e & f &  &  \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -885,9 +872,8 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 

--- a/packages/rebber-plugins/dist/type/gridTable.js
+++ b/packages/rebber-plugins/dist/type/gridTable.js
@@ -138,7 +138,7 @@ function () {
         }
 
         this.colIndex = 0;
-        var rowStr = tableRow(overriddenCtx, node);
+        var rowStr = tableRow(overriddenCtx, node, this.rowIndex - 1);
 
         if (lastMultiRowline.multilineCounter > 0) {
           rowStr = rowStr.replace(/\\hline/, lastMultiRowline.getCLine());
@@ -148,7 +148,7 @@ function () {
         return rowStr;
       }
 
-      var rowText = tableRow(overriddenCtx, node);
+      var rowText = tableRow(overriddenCtx, node, this.rowIndex - 1);
 
       if (this.currentSpan !== 0) {
         this.lastMultiRowLine = new MultiRowLine(this.rowIndex, this.rowIndex + this.currentSpan + -1, this.multiLineCellIndex, this.colIndex + this.colspan, this.colspan, this.colIndex);

--- a/packages/rebber-plugins/dist/type/gridTable.js
+++ b/packages/rebber-plugins/dist/type/gridTable.js
@@ -116,7 +116,7 @@ function () {
     }
   }, {
     key: "gridTableRow",
-    value: function gridTableRow(ctx, node) {
+    value: function gridTableRow(ctx, node, index) {
       var overriddenCtx = clone(ctx);
       this.rowIndex++;
       overriddenCtx.tableRow = undefined;
@@ -138,7 +138,7 @@ function () {
         }
 
         this.colIndex = 0;
-        var rowStr = tableRow(overriddenCtx, node, this.rowIndex - 1);
+        var rowStr = tableRow(overriddenCtx, node, index);
 
         if (lastMultiRowline.multilineCounter > 0) {
           rowStr = rowStr.replace(/\\hline/, lastMultiRowline.getCLine());
@@ -148,7 +148,7 @@ function () {
         return rowStr;
       }
 
-      var rowText = tableRow(overriddenCtx, node, this.rowIndex - 1);
+      var rowText = tableRow(overriddenCtx, node, index);
 
       if (this.currentSpan !== 0) {
         this.lastMultiRowLine = new MultiRowLine(this.rowIndex, this.rowIndex + this.currentSpan + -1, this.multiLineCellIndex, this.colIndex + this.colspan, this.colspan, this.colIndex);

--- a/packages/rebber-plugins/dist/type/tableHeader.js
+++ b/packages/rebber-plugins/dist/type/tableHeader.js
@@ -1,9 +1,22 @@
 "use strict";
 
-module.exports = function (ctx, node) {
+module.exports = function (ctx, node, index, parent) {
+  var one = require('rebber/dist/one');
+
   if (ctx.tableHeader) {
     return ctx.tableHeader(node.value);
   }
 
-  return require('rebber/dist/all')(ctx, node);
+  if (index === 0 && parent.children.length > 1) {
+    // if we are on first header row we do not want to switch back to
+    // font of normal serie
+    return node.children.map(function (n, childIndex) {
+      return one(ctx, n, childIndex === 0 ? 0 : 2, node);
+    }).join('');
+  }
+
+  var parsed = node.children.map(function (n, childIndex) {
+    return one(ctx, n, index + childIndex, node);
+  });
+  return parsed.join('');
 };

--- a/packages/rebber-plugins/src/type/gridTable.js
+++ b/packages/rebber-plugins/src/type/gridTable.js
@@ -98,7 +98,7 @@ class GridTableStringifier {
         })
       }
       this.colIndex = 0
-      let rowStr = tableRow(overriddenCtx, node)
+      let rowStr = tableRow(overriddenCtx, node, this.rowIndex - 1)
       if (lastMultiRowline.multilineCounter > 0) {
         rowStr = rowStr.replace(/\\hline/, lastMultiRowline.getCLine())
       }
@@ -106,7 +106,7 @@ class GridTableStringifier {
       return rowStr
     }
 
-    let rowText = tableRow(overriddenCtx, node)
+    let rowText = tableRow(overriddenCtx, node, this.rowIndex - 1)
     if (this.currentSpan !== 0) {
       this.lastMultiRowLine = new MultiRowLine(
         this.rowIndex,

--- a/packages/rebber-plugins/src/type/gridTable.js
+++ b/packages/rebber-plugins/src/type/gridTable.js
@@ -79,7 +79,7 @@ class GridTableStringifier {
     return baseText
   }
 
-  gridTableRow (ctx, node) {
+  gridTableRow (ctx, node, index) {
     const overriddenCtx = clone(ctx)
     this.rowIndex++
     overriddenCtx.tableRow = undefined
@@ -98,7 +98,7 @@ class GridTableStringifier {
         })
       }
       this.colIndex = 0
-      let rowStr = tableRow(overriddenCtx, node, this.rowIndex - 1)
+      let rowStr = tableRow(overriddenCtx, node, index)
       if (lastMultiRowline.multilineCounter > 0) {
         rowStr = rowStr.replace(/\\hline/, lastMultiRowline.getCLine())
       }
@@ -106,7 +106,7 @@ class GridTableStringifier {
       return rowStr
     }
 
-    let rowText = tableRow(overriddenCtx, node, this.rowIndex - 1)
+    let rowText = tableRow(overriddenCtx, node, index)
     if (this.currentSpan !== 0) {
       this.lastMultiRowLine = new MultiRowLine(
         this.rowIndex,

--- a/packages/rebber-plugins/src/type/tableHeader.js
+++ b/packages/rebber-plugins/src/type/tableHeader.js
@@ -1,6 +1,15 @@
-module.exports = (ctx, node) => {
+
+module.exports = (ctx, node, index, parent) => {
+  const one = require('rebber/dist/one')
   if (ctx.tableHeader) {
     return ctx.tableHeader(node.value)
   }
-  return require('rebber/dist/all')(ctx, node)
+  if (index === 0 && parent.children.length > 1) {
+    // if we are on first header row we do not want to switch back to
+    // font of normal serie
+    return node.children.map((n, childIndex) => one(ctx, n, childIndex === 0 ? 0 : 2, node))
+      .join('')
+  }
+  const parsed = node.children.map((n, childIndex) => one(ctx, n, index + childIndex, node))
+  return parsed.join('')
 }

--- a/packages/rebber/dist/types/tableRow.js
+++ b/packages/rebber/dist/types/tableRow.js
@@ -23,8 +23,10 @@ function tableRow(ctx, node, index) {
   var firstLineRowFont = ctx.firstLineRowFont || defaultFirstLineRowFont;
   var otherLineRowFont = ctx.otherLineRowFont || defaultOtherLineRowFont;
 
-  if (index < 2) {
-    return "".concat(index === 0 ? firstLineRowFont : otherLineRowFont, "\n").concat(macro(ctx, node));
+  if (index === 0) {
+    return "".concat(firstLineRowFont, "\n").concat(macro(ctx, node));
+  } else if (index === 1) {
+    return "".concat(otherLineRowFont, "\n").concat(macro(ctx, node));
   } else {
     return macro(ctx, node);
   }

--- a/packages/rebber/src/types/tableRow.js
+++ b/packages/rebber/src/types/tableRow.js
@@ -17,8 +17,10 @@ function tableRow (ctx, node, index) {
   const macro = ctx.tableRow || defaultMacro
   const firstLineRowFont = ctx.firstLineRowFont || defaultFirstLineRowFont
   const otherLineRowFont = ctx.otherLineRowFont || defaultOtherLineRowFont
-  if (index < 2) {
-    return `${index === 0 ? firstLineRowFont : otherLineRowFont}\n${macro(ctx, node)}`
+  if (index === 0) {
+    return `${firstLineRowFont}\n${macro(ctx, node)}`
+  } else if (index === 1) {
+    return `${otherLineRowFont}\n${macro(ctx, node)}`
   } else {
     return macro(ctx, node)
   }

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -498,9 +498,8 @@ exports[`mix-4 1`] = `
 "\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -513,7 +512,7 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & image \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -521,9 +520,8 @@ space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2}|m{\\\\dimexpr(\\\\linewidth) / 2}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 title & code \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
+inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
 block & [] \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -4146,11 +4146,9 @@ exports[`#zds #extensions properly renders grid_tables.txt 1`] = `
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
 Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
  & normal & cell \\\\\\\\ \\\\hline
 multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
@@ -4159,9 +4157,8 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|m{\\\\dimexpr(\\\\linewidth) / 3}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
 \\\\rowfont[l]{}
+\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
  & F & G \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
@@ -4235,14 +4232,13 @@ D & E & F & G \\\\\\\\ \\\\hline
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|m{\\\\dimexpr(\\\\linewidth) / 7}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
 A & \\\\multicolumn{6}{|m{\\\\dimexpr(\\\\linewidth) * 6 / 7}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} & \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|m{\\\\dimexpr(\\\\linewidth) / 4}|} \\\\cline{1-1}
 \\\\rowfont[c]{\\\\bfseries}
 D & E & F & G \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 \\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4}|}{\\\\parbox{\\\\linewidth}{H}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
  &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
  &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
  &  &  &  &  &  \\\\\\\\ \\\\hline
@@ -4372,9 +4368,8 @@ Bug \\\\#107
 \\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|m{\\\\dimexpr(\\\\linewidth) / 6}|} \\\\hline
 \\\\rowfont[c]{\\\\bfseries}
  & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{\\\\parbox{\\\\linewidth}{case1}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6}|}{\\\\parbox{\\\\linewidth}{case2}} & case3 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
  & case4 & case5 & case6 & case7 &  \\\\\\\\ \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
+\\\\rowfont[l]{}
 X & X & X & X & X & X \\\\\\\\ \\\\hline
 \\\\end{longtabu}"
 `;


### PR DESCRIPTION
This PR aims to fix the font-change line when we switch from header to body.

it embeds two related fixes : 

- do not repeat the line, especially the one with `\bfseries`
- only switch font when we enter the body, not on new line

related to #375 