### PR TITLE
[rebber] Lots of corrections and improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14682,8 +14682,10 @@
     "rebber": {
       "version": "file:packages/rebber",
       "requires": {
+        "clone": "^2.1.2",
         "has": "^1.0.3",
         "mdast-util-definitions": "^2.0.0",
+        "trim-lines": "^1.0.0",
         "xtend": "^4.0.2"
       },
       "dependencies": {

--- a/packages/rebber-plugins/README.md
+++ b/packages/rebber-plugins/README.md
@@ -12,6 +12,7 @@ It currently supports:
 * [remark-grid-tables][]
 * [remark-iframes][]
 * [remark-kbd][]
+* [remark-ping][]
 * [remark-sub-super][]
 
 ## Installation
@@ -134,6 +135,11 @@ console.log(contents);
 * `remarkConfig` needs to be configured for `remark-kbd`
 * `rebberConfig.overrides.kbd = require('rebber-plugins/dist/type/kbd')`
 
+###### [remark-ping][]
+
+* `remarkConfig` needs to be configured for `remark-ping`
+* `rebberConfig.overrides.ping = require('rebber-plugins/dist/type/ping')`
+
 
 ###### [remark-sub-super][]
 
@@ -179,5 +185,7 @@ console.log(contents);
 [remark-iframes]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-iframes#remark-iframes--
 
 [remark-kbd]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-kbd#remark-kbd--
+
+[remark-ping]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-ping#remark-ping--
 
 [remark-sub-super]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/remark-sub-super#remark-sub-super--

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -1169,6 +1169,12 @@ Asymmetrical normcore portland, vaporware viral tote bag DIY slow-carb kogi fann
 Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR\\\\&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh."
 `;
 
+exports[`ping 1`] = `
+"Hello \\\\ping{you} and \\\\ping{you_too}, and \\\\ping{also you}
+
+"
+`;
+
 exports[`regression: code block without language 1`] = `
 "\\\\begin{CodeBlock}{text}
 a

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -210,6 +210,70 @@ secret
 \\\\end{FooBar}
 
 
+\\\\begin{FooBar}
+imbricated spoilers
+
+and another
+
+and that's it
+\\\\end{FooBar}
+
+
+\\\\begin{FooBar}
+imbricated spoilers
+
+second level
+
+second level too
+\\\\end{FooBar}
+
+
+\\\\begin{FooBar}
+imbricated spoilers
+
+second level
+
+with text in between
+
+second level too
+\\\\end{FooBar}
+
+
+\\\\begin{FooBar}
+imbricated spoilers
+
+\\\\begin{CodeBlock}{markdown}
+and here is some code
+\\\\end{CodeBlock}
+
+second level
+\\\\end{FooBar}
+
+
+\\\\begin{FooBar}
+do not over-flattenize
+
+expected to be flattened
+
+first level
+
+\\\\begin{Question}
+this remains a question
+\\\\end{Question}
+\\\\end{FooBar}
+
+
+\\\\begin{FooBar}
+flattenize children of children
+
+\\\\begin{Question}
+this remains a question
+
+but the content in it is flattened to the question
+\\\\end{Question}
+\\\\end{FooBar}
+
+
 \\\\begin{Question}
 question \\\\texttt{coded}
 \\\\end{Question}

--- a/packages/rebber-plugins/__tests__/fixtures/blocks.fixture.md
+++ b/packages/rebber-plugins/__tests__/fixtures/blocks.fixture.md
@@ -7,6 +7,57 @@
 [[s]]
 | secret
 
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | and another
+| | [[s]]
+| | | and that's it
+
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | second level
+| [[s]]
+| | second level too
+
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | second level
+|
+| with text in between
+|
+| [[s]]
+| | second level too
+
+[[s]]
+| imbricated spoilers
+|
+| ```markdown
+| and here is some code
+| ```
+|
+| [[s]]
+| | second level
+
+[[s]]
+| do not over-flattenize
+| [[s]]
+| | expected to be flattened
+| 
+| first level
+| 
+| [[q]]
+| | this remains a question
+
+[[s]]
+| flattenize children of children
+| [[q]]
+| | this remains a question
+| | [[s]]
+| | | but the content in it is flattened to the question
+
 [[q]]
 | question `coded`
 

--- a/packages/rebber-plugins/__tests__/rebber.test.js
+++ b/packages/rebber-plugins/__tests__/rebber.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {readdirSync as directory, readFileSync as file, lstatSync as stat} from 'fs'
 import {join} from 'path'
 import unified from 'unified'
@@ -30,6 +29,8 @@ const integrationConfig = {
   preprocessors: {
     tableCell: require('../src/preprocessors/codeVisitor'),
     iframe: require('../src/preprocessors/iframe'),
+    // eslint-disable-next-line max-len
+    spoilerFlatten: require('../src/preprocessors/spoilerFlatten')(['sCustomBlock', 'secretCustomBlock']),
   },
   overrides: {
     abbr: require('../src/type/abbr'),

--- a/packages/rebber-plugins/__tests__/rebber.test.js
+++ b/packages/rebber-plugins/__tests__/rebber.test.js
@@ -3,6 +3,7 @@ import {join} from 'path'
 import unified from 'unified'
 import reParse from 'remark-parse'
 import remarkMath from 'remark-math'
+import remarkPing from 'remark-ping'
 import rebber from 'rebber'
 import dedent from 'dedent'
 
@@ -45,6 +46,7 @@ const integrationConfig = {
     leftAligned: require('../src/type/align'),
     math: require('../src/type/math'),
     neutreCustomBlock: require('../src/type/customBlocks'),
+    ping: require('../src/type/ping'),
     questionCustomBlock: require('../src/type/customBlocks'),
     rightAligned: require('../src/type/align'),
     secretCustomBlock: require('../src/type/customBlocks'),
@@ -428,6 +430,20 @@ test('math', () => {
       $$
 
       hehe
+    `)
+  expect(contents).toMatchSnapshot()
+})
+
+test('ping', () => {
+  const {contents} = unified()
+    .use(reParse)
+    .use(remarkPing, {
+      pingUsername: username => true,
+      userURL: username => `/membres/voir/${username}/`,
+    })
+    .use(rebber, integrationConfig)
+    .processSync(dedent`
+      Hello @you and @you_too, and @**also you**
     `)
   expect(contents).toMatchSnapshot()
 })

--- a/packages/rebber-plugins/dist/preprocessors/spoilerFlatten.js
+++ b/packages/rebber-plugins/dist/preprocessors/spoilerFlatten.js
@@ -1,0 +1,65 @@
+"use strict";
+
+var visit = require('unist-util-visit');
+
+module.exports = function (elemNames) {
+  return function (_, tree) {
+    // This should contain something like ['sCustomBlockBody', 'secretCustomBlockBody']
+    var elemNamesBody = elemNames.map(function (v) {
+      return v.concat('Body');
+    }); // Iterate over the elements to be flattened
+
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = elemNamesBody[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        var elemNameBody = _step.value;
+        visit(tree, elemNameBody, function (node) {
+          // Recursive function that flattens all matching elements and keeps the others
+          function flattenTree(blockTree) {
+            return blockTree.map(function (v) {
+              if (elemNames.includes(v.type)) {
+                // Get sCustomBlock > sCustomBlockBody > *
+                var newTree = v.children.filter(function (v) {
+                  return elemNamesBody.includes(v.type);
+                }) // This is sub-optimal, but flatMap doesn't have good support by now
+                .reduce(function (acc, e) {
+                  return acc.concat(e.children);
+                }, []); // First level of recursion: on direct descendents
+
+                return flattenTree(newTree);
+              } else {
+                // Second level of recursion: on indirect descendents
+                if (v.children) {
+                  v.children = flattenTree(v.children);
+                }
+
+                return v;
+              }
+            }).reduce(function (acc, e) {
+              return acc.concat(e);
+            }, []);
+          } // First round on direct children
+
+
+          node.children = flattenTree(node.children);
+        });
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator["return"] != null) {
+          _iterator["return"]();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
+    }
+  };
+};

--- a/packages/rebber-plugins/dist/type/kbd.js
+++ b/packages/rebber-plugins/dist/type/kbd.js
@@ -6,7 +6,7 @@ var all = require('rebber/dist/all');
 
 
 module.exports = kbd;
-/* Stringify a sub `node`. */
+/* Stringify a kbd `node`. */
 
 function kbd(ctx, node) {
   var contents = all(ctx, node);

--- a/packages/rebber-plugins/dist/type/ping.js
+++ b/packages/rebber-plugins/dist/type/ping.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/* Expose. */
+module.exports = ping;
+/* Stringify a `ping` node. */
+
+function ping(_, node) {
+  console.log(node)
+  return "\\ping{".concat(node.username, "}");
+}

--- a/packages/rebber-plugins/src/preprocessors/spoilerFlatten.js
+++ b/packages/rebber-plugins/src/preprocessors/spoilerFlatten.js
@@ -1,0 +1,38 @@
+const visit = require('unist-util-visit')
+
+module.exports = (elemNames) =>
+  (_, tree) => {
+    // This should contain something like ['sCustomBlockBody', 'secretCustomBlockBody']
+    const elemNamesBody = elemNames.map(v => v.concat('Body'))
+
+    // Iterate over the elements to be flattened
+    for (const elemNameBody of elemNamesBody) {
+      visit(tree, elemNameBody, node => {
+        // Recursive function that flattens all matching elements and keeps the others
+        function flattenTree (blockTree) {
+          return blockTree.map(v => {
+            if (elemNames.includes(v.type)) {
+              // Get sCustomBlock > sCustomBlockBody > *
+              const newTree = v.children
+                .filter(v => elemNamesBody.includes(v.type))
+                // This is sub-optimal, but flatMap doesn't have good support by now
+                .reduce((acc, e) => acc.concat(e.children), [])
+
+              // First level of recursion: on direct descendents
+              return flattenTree(newTree)
+            } else {
+              // Second level of recursion: on indirect descendents
+              if (v.children) {
+                v.children = flattenTree(v.children)
+              }
+
+              return v
+            }
+          }).reduce((acc, e) => acc.concat(e), [])
+        }
+
+        // First round on direct children
+        node.children = flattenTree(node.children)
+      })
+    }
+  }

--- a/packages/rebber-plugins/src/type/kbd.js
+++ b/packages/rebber-plugins/src/type/kbd.js
@@ -4,7 +4,7 @@ const all = require('rebber/dist/all')
 /* Expose. */
 module.exports = kbd
 
-/* Stringify a sub `node`. */
+/* Stringify a kbd `node`. */
 function kbd (ctx, node) {
   const contents = all(ctx, node)
 

--- a/packages/rebber-plugins/src/type/ping.js
+++ b/packages/rebber-plugins/src/type/ping.js
@@ -1,0 +1,7 @@
+/* Expose. */
+module.exports = ping
+
+/* Stringify a `ping` node. */
+function ping (_, node) {
+  return `\\ping{${node.username}}`
+}

--- a/packages/rebber/package.json
+++ b/packages/rebber/package.json
@@ -31,8 +31,10 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "clone": "^2.1.2",
     "has": "^1.0.3",
     "mdast-util-definitions": "^2.0.0",
+    "trim-lines": "^1.0.0",
     "xtend": "^4.0.2"
   }
 }

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -707,6 +707,8 @@ Asymmetrical normcore portland, vaporware viral tote bag DIY slow-carb kogi fann
 Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR\\\\&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh."
 `;
 
+exports[`ping 1`] = `"Hello \\\\ping{you} and \\\\ping{you_too}, and \\\\ping{also you}"`;
+
 exports[`regression: code block without language 1`] = `
 "\\\\begin{CodeBlock}{text}
 a

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -124,6 +124,70 @@ secret
 \\\\end{Spoiler}
 
 
+\\\\begin{Spoiler}
+imbricated spoilers
+
+and another
+
+and that's it
+\\\\end{Spoiler}
+
+
+\\\\begin{Spoiler}
+imbricated spoilers
+
+second level
+
+second level too
+\\\\end{Spoiler}
+
+
+\\\\begin{Spoiler}
+imbricated spoilers
+
+second level
+
+with text in between
+
+second level too
+\\\\end{Spoiler}
+
+
+\\\\begin{Spoiler}
+imbricated spoilers
+
+\\\\begin{CodeBlock}{markdown}
+and here is some code
+\\\\end{CodeBlock}
+
+second level
+\\\\end{Spoiler}
+
+
+\\\\begin{Spoiler}
+do not over-flattenize
+
+expected to be flattened
+
+first level
+
+\\\\begin{Question}
+this remains a question
+\\\\end{Question}
+\\\\end{Spoiler}
+
+
+\\\\begin{Spoiler}
+flattenize children of children
+
+\\\\begin{Question}
+this remains a question
+
+but the content in it is flattened to the question
+\\\\end{Question}
+\\\\end{Spoiler}
+
+
 \\\\begin{Question}
 question \\\\CodeInline{coded}
 \\\\end{Question}

--- a/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.tests.js.snap
@@ -35,6 +35,29 @@ exports[`Texfile endpoint accepts POSTed markdown 1`] = `
 \\\\end{document}"
 `;
 
+exports[`Texfile endpoint allows extra arguments 1`] = `
+"\\\\documentclass[contentType]{zmdocument}
+
+\\\\usepackage{blindtext}
+\\\\title{The Title}
+\\\\author{FØØ, Bär}
+\\\\licence[/tmp/l/by-nc-sa.svg]{CC-BY-NC-SA}{https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode}
+\\\\logo{/tmp/logo/h2g2.png}
+\\\\editorLogo{/tmp/logo/pmm.jpg}
+\\\\tutoLink{https://en.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy_(novel)}
+\\\\editor{https://www.panmacmillan.com/}
+\\\\smileysPath{/tmp/s}
+\\\\makeglossaries
+
+\\\\begin{document}
+\\\\maketitle
+\\\\tableofcontents
+
+\\\\levelOneTitle{foo}
+
+\\\\end{document}"
+`;
+
 exports[`Texfile endpoint escapes title and author 1`] = `
 "\\\\documentclass[contentType]{zmdocument}
 

--- a/packages/zmarkdown/__tests__/fixtures/latex/blocks.fixture.md
+++ b/packages/zmarkdown/__tests__/fixtures/latex/blocks.fixture.md
@@ -7,6 +7,57 @@
 [[s]]
 | secret
 
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | and another
+| | [[s]]
+| | | and that's it
+
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | second level
+| [[s]]
+| | second level too
+
+[[s]]
+| imbricated spoilers
+| [[s]]
+| | second level
+|
+| with text in between
+|
+| [[s]]
+| | second level too
+
+[[s]]
+| imbricated spoilers
+|
+| ```markdown
+| and here is some code
+| ```
+|
+| [[s]]
+| | second level
+
+[[s]]
+| do not over-flattenize
+| [[s]]
+| | expected to be flattened
+| 
+| first level
+| 
+| [[q]]
+| | this remains a question
+
+[[s]]
+| flattenize children of children
+| [[q]]
+| | this remains a question
+| | [[s]]
+| | | but the content in it is flattened to the question
+
 [[q]]
 | question `coded`
 

--- a/packages/zmarkdown/__tests__/latex.tests.js
+++ b/packages/zmarkdown/__tests__/latex.tests.js
@@ -8,7 +8,6 @@ const rebberConfig = require('../config/rebber')
 
 remarkConfig.noTypography = true
 remarkConfig._test = true
-remarkConfig.ping.pingUsername = () => false
 
 const zmarkdown = require('../server')
 
@@ -174,6 +173,13 @@ test('math', () => {
 
     hehe
   `)
+  return expect(p).resolves.toMatchSnapshot()
+})
+
+test('ping', () => {
+  const p = renderString()(dedent`
+      Hello @you and @you_too, and @**also you**
+    `)
   return expect(p).resolves.toMatchSnapshot()
 })
 

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -328,6 +328,26 @@ describe('Texfile endpoint', () => {
     const [, dir, file, ext] = rendered.match(regex)
     return expect(rm(`${destination}/${dir}`, `${file}.${ext}`)).resolves.toBe('ok')
   })
+
+  it('allows extra arguments', async () => {
+    const additionalOpts = {
+      logo_directory: '/tmp/logo',
+      content_logo: 'h2g2.png',
+      content_link: 'https://en.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy_(novel)',
+      editor_logo: 'pmm.jpg',
+      editor_link: 'https://www.panmacmillan.com/',
+    }
+    const opts = Object.assign({}, texfileOpts, additionalOpts)
+    const response = await a.post(texfile, {md: '# foo', opts})
+    expect(response.status).toBe(200)
+
+    const [string] = response.data
+    expect(string).toMatchSnapshot()
+    expect(string).toContain(dedent`\logo{/tmp/logo/h2g2.png}
+    \editorLogo{/tmp/logo/pmm.jpg}
+    \tutoLink{https://en.wikipedia.org/wiki/The_Hitchhiker%27s_Guide_to_the_Galaxy_(novel)}
+    \editor{https://www.panmacmillan.com/}`)
+  })
 })
 
 

--- a/packages/zmarkdown/__tests__/server.tests.js
+++ b/packages/zmarkdown/__tests__/server.tests.js
@@ -81,6 +81,31 @@ describe('HTML endpoint', () => {
     expect(languages).toEqual([])
   })
 
+  it('can disable tokenizers', async () => {
+    const response = await a.post(html, {
+      md: '# foo\nhello bar!',
+      opts: {disable_tokenizers: {block: ['atxHeading']}},
+    })
+
+    const [rendered] = response.data
+    expect(rendered).not.toContain('<h')
+  })
+
+  it('can disable tokenizers in inline mode', async () => {
+    const response = await a.post(html, {
+      md: '# foo\n*hello bar!*',
+      opts: {
+        inline: true,
+        disable_tokenizers: {inline: ['emphasis']},
+      },
+    })
+
+    const [rendered, {languages}] = response.data
+    expect(rendered).not.toContain('<h')
+    expect(rendered).not.toContain('<em')
+    expect(languages).toEqual([])
+  })
+
   it('extracts languages', async () => {
     const response = await a.post(html, {
       md: dedent`

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -16,6 +16,7 @@ const rebberConfig = {
     inlineMath: require('rebber-plugins/dist/type/math'),
     kbd: require('rebber-plugins/dist/type/kbd'),
     math: require('rebber-plugins/dist/type/math'),
+    ping: require('rebber-plugins/dist/type/ping'),
     sub: require('rebber-plugins/dist/type/sub'),
     sup: require('rebber-plugins/dist/type/sup'),
     tableHeader: require('rebber-plugins/dist/type/tableHeader'),

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -1,9 +1,11 @@
+/* eslint-disable max-len */
 const remarkConfig = require('./remark')
 const escape = require('rebber/dist/escaper')
 
 const rebberConfig = {
   preprocessors: {
     tableCell: require('rebber-plugins/dist/preprocessors/codeVisitor'),
+    spoilerFlatten: require('rebber-plugins/dist/preprocessors/spoilerFlatten')(['sCustomBlock', 'secretCustomBlock']),
   },
   overrides: {
     abbr: require('rebber-plugins/dist/type/abbr'),

--- a/packages/zmarkdown/server/handlers.js
+++ b/packages/zmarkdown/server/handlers.js
@@ -100,7 +100,7 @@ module.exports = function markdownHandlers (Raven) {
       return callback(new Error(`Unknown target 'target=${target}'`))
     }
 
-    /* zmd parser memoization */
+    /* zmd parser options */
     const key = String(target) + JSON.stringify(opts)
     if (!processors.hasOwnProperty(key)) {
       const remark = clone(remarkConfig)
@@ -119,8 +119,14 @@ module.exports = function markdownHandlers (Raven) {
         remark.iframes['jsfiddle.net'].disabled = true
         remark.iframes['www.jsfiddle.net'].disabled = true
       }
+
+      if (typeof opts.disable_tokenizers === 'object' && !Array.isArray(opts.disable_tokenizers)) {
+        remark.disableTokenizers = opts.disable_tokenizers
+      }
+
       remark.stats = opts.stats === true
       remark.imagesDownload.disabled = opts.disable_images_download === true
+
       if (remark.imagesDownload.disabled !== true) {
         if (opts.images_download_dir) {
           remark.imagesDownload.downloadDestination = opts.images_download_dir
@@ -140,18 +146,20 @@ module.exports = function markdownHandlers (Raven) {
       }
 
       if (opts.inline === true) {
-        remark.disableTokenizers = {
-          block: [
-            'indentedCode',
-            'fencedCode',
-            'blockquote',
-            'atxHeading',
-            'setextHeading',
-            'footnote',
-            'table',
-            'custom_blocks',
-          ],
+        if (!Array.isArray(remark.disableTokenizers.block)) {
+          remark.disableTokenizers.block = []
         }
+
+        remark.disableTokenizers.block = remark.disableTokenizers.block.concat([
+          'indentedCode',
+          'fencedCode',
+          'blockquote',
+          'atxHeading',
+          'setextHeading',
+          'footnote',
+          'table',
+          'custom_blocks',
+        ])
       }
 
       processors[key] = zmarkdown({

--- a/packages/zmarkdown/templates/latex-document.js
+++ b/packages/zmarkdown/templates/latex-document.js
@@ -8,6 +8,11 @@ const template = (opts, callback) => {
     license_directory: licenseDirectory,
     license_url: licenseUrl,
     license_logo: licenseLogo,
+    logo_directory: logoDirectory,
+    content_logo: contentLogo,
+    content_link: contentLink,
+    editor_logo: editorLogo,
+    editor_link: editorLink,
     smileys_directory: smileysDirectory,
     title,
     authors,
@@ -15,6 +20,7 @@ const template = (opts, callback) => {
     latex,
   } = opts
   try {
+    // Required options
     assert(contentType, 'Error with argument: "contentType"')
     assert(title, 'Error with argument: "title"')
     assert(Array.isArray(authors), 'Error with argument: "authors"')
@@ -25,8 +31,16 @@ const template = (opts, callback) => {
   } catch (err) {
     return callback(err)
   }
-  const logoPath = licenseLogo ? `${licenseDirectory}/${licenseLogo}` : ''
-  const licenseLine = `\\licence[${logoPath}]{${license}}{${licenseUrl || ''}}`
+
+  const licenceLogoPath = licenseLogo ? `${licenseDirectory}/${licenseLogo}` : ''
+  const licenseLine = `\\licence[${licenceLogoPath}]{${license}}{${licenseUrl || ''}}`
+
+  // Optional arguments
+  const extraHeaders = []
+  if (logoDirectory && contentLogo) extraHeaders.push(`\\logo{${logoDirectory}/${contentLogo}}`)
+  if (logoDirectory && editorLogo) extraHeaders.push(`\\editorLogo{${logoDirectory}/${editorLogo}}`)
+  if (contentLink) extraHeaders.push(`\\tutoLink{${contentLink}}`)
+  if (editorLink) extraHeaders.push(`\\editor{${editorLink}}`)
 
   return callback(null, `\\documentclass[${contentType}]{zmdocument}
 
@@ -34,7 +48,7 @@ const template = (opts, callback) => {
 \\title{${escape(title)}}
 \\author{${escape(authors.join(', '))}}
 ${licenseLine}
-
+${extraHeaders.join('\n')}
 \\smileysPath{${smileysDirectory}}
 \\makeglossaries
 


### PR DESCRIPTION
These are the last changes until next release; I plan on publishing a major version of rebber, which requires the following to be solved:

- add `mhchem` (#359): done and merged;
- array improvements (#374): done and merged;
- array issue (#375): done and merged;
- avoid spoiler in spoiler (#280): done, first in this PR;
- allow to disable custom tokenizers (for #313): done, second in this PR but not sure it solves the issue;
- add options to zmarkdown's LaTeX endpoint (#283 *only*): done, third in this PR;
- send codeblocks to appendices (#299): done and merged;
- add a `\ping` command (none): done, fourth in this PR;
- add missing dependencies to rebber (#384): done, fifth in this PR.

We will be able to publish soon enough, now everything is done.