### PR TITLE
Solve the footnote order problem

### DIFF
--- a/packages/remark-numbered-footnotes/README.md
+++ b/packages/remark-numbered-footnotes/README.md
@@ -1,37 +1,5 @@
-This plugin replaces the footnote references with a number sequence (starting from 1) in the same order as the footnote definitions (**not** the footnote references).
-
-Reordering the definitions (usually put at the end of the document in the Markdown source) will therefore let you reorder the sequence.
+This plugin replaces the footnote references with a number sequence (starting from 1) in the same order as the footnote references (like `mdast-util-to-hast`, starting from version 6.0.0).
 
 This is useful if you want your footnotes to be superscript numbers without having to manually enter them while keeping the benefit of using strings that make sense to you in your Markdown source.
 
-# Warning
-
-If you are using this plugin, your project is most certainly relying on [mdast-util-to-hast](https://github.com/syntax-tree/mdast-util-to-hast). Run `npm ls mdast-util-to-hast` if you're unsure.
-Starting from `mdast-util-to-hast@6.0.0`, the [footnote order changed](https://github.com/syntax-tree/mdast-util-to-hast/commit/fd38c45421bbec497f56e5c624eb8652d3a3bba4). Before `6.0.0`, footnotes were following the order in which they were defined, starting from `6.0.0` they follow the order of the references.
-
-```md
-a[^first_footnote_reference]
-
-b[^`b` second footnote reference but first footnote definition]
-
-c[^last_footnote_reference]
-
-[^last_footnote_reference]: `c` last footnote reference but second footnote definition
-[^first_footnote_reference]: `a` first footnote reference but last footnote definition
-```
-
-Before `6.0.0`:
-
-![image](https://user-images.githubusercontent.com/2022803/73589529-7207e980-44d7-11ea-8c67-cd8a20d961fe.png)
-
-After `6.0.0`:
-
-![image](https://user-images.githubusercontent.com/2022803/73589535-7cc27e80-44d7-11ea-90e0-3e0e0dbac87c.png)
-
-In the HTML ordered list, the list items 1/2/3 don't match the footnote references numbers anymore.
-
-To avoid this issue you can either use older versions of your dependencies (not recommended) or visit the HAST tree after `mdast-util-to-hast` to fix the footnote orders (recommended).
-[Here is an example](https://github.com/zestedesavoir/zmarkdown/blob/7edd73057aba4eba52600106c6f8511619f045bd/packages/zmarkdown/common.js#L175-L206).
-This way the above markdown will always generate HTML with matching footnote list items and footnote numbered references as can be seen below:
-
-![image](https://user-images.githubusercontent.com/2022803/73589529-7207e980-44d7-11ea-8c67-cd8a20d961fe.png)
+Be careful when using an older version of `mdast-util-to-hast` than 6.0.0, your footnotes order may not match the references given. If it is the case, then you can either downgrade `remark-numbered-footnotes` to version 1.x.x or upgrade `mdast-util-to-hast` to version 6.0.0.

--- a/packages/remark-numbered-footnotes/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-numbered-footnotes/__tests__/__snapshots__/index.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`{"gfm":false,"commonmark":false,"footnotes":true} footnote-split 1`] = `
-"<p>a<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>b<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
+"<p>a<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>b<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
-<li id=\\"fn-2\\">first def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-1\\">second def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-1\\">first def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-2\\">second def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">third def<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
@@ -67,28 +67,28 @@ exports[`{"gfm":false,"commonmark":false,"footnotes":true} regression-2 1`] = `
 "<p>1 <sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>
 2 <sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>
 3 <sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-5 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup></p>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+5 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
 <li id=\\"fn-1\\">alpha bravo one<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-2\\">alpha bravo two<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">alpha bravo third<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-5\\">foo<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-4\\">alpha bravo fourth<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-4\\">foo<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-5\\">alpha bravo fourth<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
 `;
 
 exports[`{"gfm":false,"commonmark":true,"footnotes":true} footnote-split 1`] = `
-"<p>a<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>b<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
+"<p>a<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>b<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
-<li id=\\"fn-2\\">first def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-1\\">second def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-1\\">first def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-2\\">second def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">third def<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
@@ -149,28 +149,28 @@ exports[`{"gfm":false,"commonmark":true,"footnotes":true} regression-2 1`] = `
 "<p>1 <sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>
 2 <sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>
 3 <sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-5 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup></p>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+5 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
 <li id=\\"fn-1\\">alpha bravo one<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-2\\">alpha bravo two<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">alpha bravo third<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-5\\">foo<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-4\\">alpha bravo fourth<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-4\\">foo<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-5\\">alpha bravo fourth<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
 `;
 
 exports[`{"gfm":true,"commonmark":false,"footnotes":true} footnote-split 1`] = `
-"<p>a<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>b<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
+"<p>a<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>b<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
-<li id=\\"fn-2\\">first def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-1\\">second def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-1\\">first def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-2\\">second def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">third def<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
@@ -231,28 +231,28 @@ exports[`{"gfm":true,"commonmark":false,"footnotes":true} regression-2 1`] = `
 "<p>1 <sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>
 2 <sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>
 3 <sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-5 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup></p>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+5 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
 <li id=\\"fn-1\\">alpha bravo one<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-2\\">alpha bravo two<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">alpha bravo third<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-5\\">foo<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-4\\">alpha bravo fourth<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-4\\">foo<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-5\\">alpha bravo fourth<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
 `;
 
 exports[`{"gfm":true,"commonmark":true,"footnotes":true} footnote-split 1`] = `
-"<p>a<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>b<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
+"<p>a<sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>b<sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>c<sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
-<li id=\\"fn-2\\">first def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-1\\">second def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-1\\">first def<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-2\\">second def<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">third def<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
@@ -313,17 +313,17 @@ exports[`{"gfm":true,"commonmark":true,"footnotes":true} regression-2 1`] = `
 "<p>1 <sup id=\\"fnref-1\\"><a href=\\"#fn-1\\" class=\\"footnote-ref\\">1</a></sup>
 2 <sup id=\\"fnref-2\\"><a href=\\"#fn-2\\" class=\\"footnote-ref\\">2</a></sup>
 3 <sup id=\\"fnref-3\\"><a href=\\"#fn-3\\" class=\\"footnote-ref\\">3</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-4 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup>
-5 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup></p>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+4 <sup id=\\"fnref-4\\"><a href=\\"#fn-4\\" class=\\"footnote-ref\\">4</a></sup>
+5 <sup id=\\"fnref-5\\"><a href=\\"#fn-5\\" class=\\"footnote-ref\\">5</a></sup></p>
 <div class=\\"footnotes\\">
 <hr>
 <ol>
 <li id=\\"fn-1\\">alpha bravo one<a href=\\"#fnref-1\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-2\\">alpha bravo two<a href=\\"#fnref-2\\" class=\\"footnote-backref\\">↩</a></li>
 <li id=\\"fn-3\\">alpha bravo third<a href=\\"#fnref-3\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-5\\">foo<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
-<li id=\\"fn-4\\">alpha bravo fourth<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-4\\">foo<a href=\\"#fnref-4\\" class=\\"footnote-backref\\">↩</a></li>
+<li id=\\"fn-5\\">alpha bravo fourth<a href=\\"#fnref-5\\" class=\\"footnote-backref\\">↩</a></li>
 </ol>
 </div>"
 `;

--- a/packages/remark-numbered-footnotes/dist/index.js
+++ b/packages/remark-numbered-footnotes/dist/index.js
@@ -9,8 +9,8 @@ function plugin() {
 function transformer(tree) {
   var footnotes = {};
   visit(tree, 'footnote', convert);
-  visit(tree, 'footnoteDefinition', createIds(footnotes));
-  visit(tree, 'footnoteReference', replaceIds(footnotes));
+  visit(tree, 'footnoteReference', createIds(footnotes));
+  visit(tree, 'footnoteDefinition', replaceIds(footnotes));
 }
 
 function convert(node, index, parent) {

--- a/packages/remark-numbered-footnotes/src/index.js
+++ b/packages/remark-numbered-footnotes/src/index.js
@@ -8,9 +8,9 @@ function transformer (tree) {
   const footnotes = {}
   visit(tree, 'footnote', convert)
 
-  visit(tree, 'footnoteDefinition', createIds(footnotes))
+  visit(tree, 'footnoteReference', createIds(footnotes))
 
-  visit(tree, 'footnoteReference', replaceIds(footnotes))
+  visit(tree, 'footnoteDefinition', replaceIds(footnotes))
 }
 
 function convert (node, index, parent) {

--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -172,37 +172,6 @@ function getHTMLProcessor (config) {
           visit(tree, wrapper)
         }))
     })
-    // Reorder footnotes
-    .use(() => (tree) => {
-      // Find .footnotes > ol
-      visit(tree, (node, _, parent) => {
-        if (node.type === 'element' &&
-            node.tagName === 'ol' &&
-            parent.properties &&
-            parent.properties.className &&
-            parent.properties.className.includes('footnotes')
-        ) {
-          // Get all the footnotes
-          const footnotes = node.children.filter(c => c.type === 'element' && c.tagName === 'li')
-
-          // Reorder footnotes
-          footnotes.sort((a, b) => {
-            const aId = parseInt(a.properties.id.split('-')[1])
-            const bId = parseInt(b.properties.id.split('-')[1])
-
-            // We assume the two ids are never equals
-            return aId > bId ? -1 : 1
-          })
-
-          // Interchange footnotes in HAST
-          node.children.forEach((child, id) => {
-            if (child.type === 'element' && child.tagName === 'li') {
-              node.children[id] = footnotes.pop()
-            }
-          })
-        }
-      })
-    })
     .use(rehypeStringify)
 }
 


### PR DESCRIPTION
Really simple fix to the footnote order problem that wasn't really solved when updating dependencies.

Before, we did:

- visit the definitions and number the footnotes in this order;
- apply the numbers to the references.

But recently, `mdast-util-to-hast` broke the module by numbering the footnotes at the end in the references order; until now, we had a trick on zmarkdown to keep the old behaviour, this PR aims to fix the problem directly inside the package:

- visit the references and number the footnotes in this order;
- apply the numbers to the definitions.

This behaviour needs to be validated by @artragis though, as it does differ from the previous one: when updating a content, the footnotes order could change.