### PR TITLE
rebber/rebber-plugins: fix appendix management for gridtables and footnotes

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -325,7 +325,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -456,8 +456,6 @@ elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\
 \\\\begin{CodeBlock}{python}
 print('bla')
 \\\\end{CodeBlock}
-
-
 \\\\end{appendices}"
 `;
 
@@ -836,7 +834,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -959,8 +957,6 @@ b &  &  & c \\\\\\\\ \\\\hline
 \\\\begin{CodeBlock}{python}
 print('bla')
 \\\\end{CodeBlock}
-
-
 \\\\end{appendices}"
 `;
 
@@ -990,7 +986,7 @@ exports[`mix-7 1`] = `
 \\\\rowfont[c]{\\\\bfseries}
 cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{\\\\hyperref[appendix-1]{code}}} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{\\\\hyperref[appendix-1]{Code appendice 1}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -1001,8 +997,6 @@ cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 line 1
 line2
 \\\\end{CodeBlock}
-
-
 \\\\end{appendices}"
 `;
 

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -451,7 +451,7 @@ elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\
 
 
 \\\\begin{appendices}
-\\\\label{appendix-1}appendix 1
+\\\\part{\\\\label{appendix-1}Annexes 1}
 
 \\\\begin{CodeBlock}{python}
 print('bla')
@@ -954,7 +954,7 @@ b &  &  & c \\\\\\\\ \\\\hline
 
 
 \\\\begin{appendices}
-\\\\label{appendix-1}appendix 1
+\\\\part{\\\\label{appendix-1}Annexes 1}
 
 \\\\begin{CodeBlock}{python}
 print('bla')
@@ -995,7 +995,7 @@ cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 
 
 \\\\begin{appendices}
-\\\\label{appendix-1}appendix 1
+\\\\part{\\\\label{appendix-1}Annexes 1}
 
 \\\\begin{CodeBlock}{text}
 line 1

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -325,7 +325,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -836,7 +836,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -990,7 +990,7 @@ exports[`mix-7 1`] = `
 \\\\rowfont[c]{\\\\bfseries}
 cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{\\\\href{appendix-1}{code}}} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{\\\\hyperref[appendix-1]{code}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -325,7 +325,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & [] \\\\\\\\ \\\\hline
+block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -450,13 +450,15 @@ elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5}|}{\\\\parbox{\\
 \\\\end{longtabu}
 
 
-\\\\part{Annexes}
+\\\\begin{appendices}
+\\\\label{appendix-1}appendix 1
 
-
-\\\\footnote{\\\\label{appendix-1}}
 \\\\begin{CodeBlock}{python}
 print('bla')
-\\\\end{CodeBlock}"
+\\\\end{CodeBlock}
+
+
+\\\\end{appendices}"
 `;
 
 exports[`heading 1`] = `
@@ -834,7 +836,7 @@ space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & [] \\\\\\\\ \\\\hline
+block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -951,13 +953,15 @@ b &  &  & c \\\\\\\\ \\\\hline
 
 
 
-\\\\part{Annexes}
+\\\\begin{appendices}
+\\\\label{appendix-1}appendix 1
 
-
-\\\\footnote{\\\\label{appendix-1}}
 \\\\begin{CodeBlock}{python}
 print('bla')
-\\\\end{CodeBlock}"
+\\\\end{CodeBlock}
+
+
+\\\\end{appendices}"
 `;
 
 exports[`mix-5 1`] = `
@@ -986,18 +990,20 @@ exports[`mix-7 1`] = `
 \\\\rowfont[c]{\\\\bfseries}
 cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{[]}} \\\\\\\\ \\\\hline
+\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2}|}{\\\\parbox{\\\\linewidth}{\\\\href{appendix-1}{code}}} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\part{Annexes}
+\\\\begin{appendices}
+\\\\label{appendix-1}appendix 1
 
-
-\\\\footnote{\\\\label{appendix-1}}
 \\\\begin{CodeBlock}{text}
 line 1
 line2
-\\\\end{CodeBlock}"
+\\\\end{CodeBlock}
+
+
+\\\\end{appendices}"
 `;
 
 exports[`paragraph 1`] = `

--- a/packages/rebber-plugins/dist/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/dist/preprocessors/codeVisitor.js
@@ -2,9 +2,6 @@
 
 var visit = require('unist-util-visit');
 
-var _require = require('rebber/dist/preprocessors/referenceVisitors')(),
-    addIdentifier = _require.addIdentifier;
-
 var appendix = require('../type/appendix');
 
 module.exports = function (ctx, tree) {
@@ -25,21 +22,21 @@ module.exports = function (ctx, tree) {
       appendix.children.push({
         type: 'paragraph',
         children: [{
-          type: 'definition',
-          identifier: "appendix-".concat(appendixIndex),
-          url: "appendix ".concat(appendixIndex),
-          referenceType: 'full',
+          type: 'heading',
           children: [{
-            type: 'text',
-            value: 'code'
-          }]
-        }, {
-          type: 'text',
-          value: '\n'
+            type: 'definition',
+            identifier: "appendix-".concat(appendixIndex),
+            url: "".concat(ctx.codeAppendiceTitle || 'Appendix', " ").concat(appendixIndex),
+            referenceType: 'full',
+            children: [{
+              type: 'text',
+              value: 'code'
+            }]
+          }],
+          depth: 1
         }]
       });
       appendix.children.push(innerNode);
-      addIdentifier("appendix-".concat(appendixIndex), 'code');
       var referenceNode = {
         type: 'linkReference',
         identifier: "appendix-".concat(appendixIndex),

--- a/packages/rebber-plugins/dist/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/dist/preprocessors/codeVisitor.js
@@ -4,6 +4,10 @@ var visit = require('unist-util-visit');
 
 var appendix = require('../type/appendix');
 
+var defaultReferenceGenerator = function defaultReferenceGenerator(appendixIndex) {
+  return "Code appendice ".concat(appendixIndex);
+};
+
 module.exports = function (ctx, tree) {
   ctx.overrides.appendix = appendix;
   return function (node) {
@@ -27,22 +31,19 @@ module.exports = function (ctx, tree) {
             type: 'definition',
             identifier: "appendix-".concat(appendixIndex),
             url: "".concat(ctx.codeAppendiceTitle || 'Appendix', " ").concat(appendixIndex),
-            referenceType: 'full',
-            children: [{
-              type: 'text',
-              value: 'code'
-            }]
+            referenceType: 'full'
           }],
           depth: 1
         }]
       });
       appendix.children.push(innerNode);
+      var generator = ctx.appendiceReferenceGenerator || defaultReferenceGenerator;
       var referenceNode = {
         type: 'linkReference',
         identifier: "appendix-".concat(appendixIndex),
         children: [{
           type: 'text',
-          value: 'code'
+          value: generator(appendixIndex)
         }]
       };
 

--- a/packages/rebber-plugins/dist/type/appendix.js
+++ b/packages/rebber-plugins/dist/type/appendix.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/* Dependencies. */
+var all = require('rebber/dist/all');
+
+var clone = require('clone');
+/* Expose. */
+
+
+module.exports = appendixPlugin;
+
+function definitionMacro(ctx, identifier, url) {
+  return "\\label{".concat(identifier, "}").concat(url);
+}
+
+function appendixPlugin(ctx, node) {
+  if (node.children.length === 0) {
+    return '';
+  }
+
+  var overriddenCtx = clone(ctx);
+  overriddenCtx.definition = definitionMacro;
+  var innerText = all(overriddenCtx, node);
+  return "\\begin{appendices}\n".concat(innerText, "\n\\end{appendices}");
+}

--- a/packages/rebber-plugins/dist/type/appendix.js
+++ b/packages/rebber-plugins/dist/type/appendix.js
@@ -21,5 +21,5 @@ function appendixPlugin(ctx, node) {
   var overriddenCtx = clone(ctx);
   overriddenCtx.definition = definitionMacro;
   var innerText = all(overriddenCtx, node);
-  return "\\begin{appendices}\n".concat(innerText, "\n\\end{appendices}");
+  return "\\begin{appendices}\n".concat(innerText.trimEnd(), "\n\\end{appendices}");
 }

--- a/packages/rebber-plugins/src/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/src/preprocessors/codeVisitor.js
@@ -1,41 +1,50 @@
 const visit = require('unist-util-visit')
+const {addIdentifier} = require('rebber/dist/preprocessors/referenceVisitors')()
+const appendix = require('../type/appendix')
 
 module.exports = (ctx, tree) => {
-  const title = ctx.codeAppendiceTitle || 'Appendices'
+  ctx.overrides.appendix = appendix
   return (node) => {
-    const inAppendix = []
-    let appendixIndex = 1
-
+    let appendix = tree.children[tree.children.length - 1]
+    if (!appendix || appendix.type !== 'appendix') {
+      appendix = {
+        type: 'appendix',
+        children: [],
+      }
+      tree.children.push(appendix)
+    }
+    let appendixIndex = appendix.children.length + 1
     visit(node, 'code', (innerNode, index, _parent) => {
-      inAppendix.push({
+
+      appendix.children.push({
         type: 'paragraph',
         children: [
           {
             type: 'definition',
             identifier: `appendix-${appendixIndex}`,
+            url: `appendix ${appendixIndex}`,
             referenceType: 'full',
             children: [{type: 'text', value: 'code'}],
           },
           {type: 'text', value: '\n'},
-          innerNode,
+
         ],
       })
+      appendix.children.push(innerNode)
+      addIdentifier(`appendix-${appendixIndex}`, 'code')
       const referenceNode = {
         type: 'linkReference',
         identifier: `appendix-${appendixIndex}`,
+        children: [
+          {
+            type: 'text',
+            value: 'code',
+          },
+        ],
       }
       _parent.children.splice(index, 1, referenceNode)
       appendixIndex++
     })
 
-    if (inAppendix.length) {
-      tree.children.push({
-        type: 'heading',
-        depth: 1,
-        children: [{type: 'text', value: title}],
-
-      })
-      inAppendix.forEach((element) => tree.children.push(element))
-    }
   }
 }

--- a/packages/rebber-plugins/src/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/src/preprocessors/codeVisitor.js
@@ -14,14 +14,12 @@ module.exports = (ctx, tree) => {
     }
     let appendixIndex = appendix.children.length + 1
     visit(node, 'code', (innerNode, index, _parent) => {
-
       appendix.children.push({
         type: 'paragraph',
         children: [
           {
             type: 'heading',
             children: [
-
               {
                 type: 'definition',
                 identifier: `appendix-${appendixIndex}`,
@@ -34,7 +32,9 @@ module.exports = (ctx, tree) => {
           },
         ],
       })
+
       appendix.children.push(innerNode)
+
       const referenceNode = {
         type: 'linkReference',
         identifier: `appendix-${appendixIndex}`,

--- a/packages/rebber-plugins/src/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/src/preprocessors/codeVisitor.js
@@ -1,5 +1,4 @@
 const visit = require('unist-util-visit')
-const {addIdentifier} = require('rebber/dist/preprocessors/referenceVisitors')()
 const appendix = require('../type/appendix')
 
 module.exports = (ctx, tree) => {
@@ -20,18 +19,22 @@ module.exports = (ctx, tree) => {
         type: 'paragraph',
         children: [
           {
-            type: 'definition',
-            identifier: `appendix-${appendixIndex}`,
-            url: `appendix ${appendixIndex}`,
-            referenceType: 'full',
-            children: [{type: 'text', value: 'code'}],
-          },
-          {type: 'text', value: '\n'},
+            type: 'heading',
+            children: [
 
+              {
+                type: 'definition',
+                identifier: `appendix-${appendixIndex}`,
+                url: `${ctx.codeAppendiceTitle || 'Appendix'} ${appendixIndex}`,
+                referenceType: 'full',
+                children: [{type: 'text', value: 'code'}],
+              },
+            ],
+            depth: 1,
+          },
         ],
       })
       appendix.children.push(innerNode)
-      addIdentifier(`appendix-${appendixIndex}`, 'code')
       const referenceNode = {
         type: 'linkReference',
         identifier: `appendix-${appendixIndex}`,

--- a/packages/rebber-plugins/src/preprocessors/codeVisitor.js
+++ b/packages/rebber-plugins/src/preprocessors/codeVisitor.js
@@ -1,6 +1,8 @@
 const visit = require('unist-util-visit')
 const appendix = require('../type/appendix')
 
+const defaultReferenceGenerator = (appendixIndex) => `Code appendice ${appendixIndex}`
+
 module.exports = (ctx, tree) => {
   ctx.overrides.appendix = appendix
   return (node) => {
@@ -25,7 +27,6 @@ module.exports = (ctx, tree) => {
                 identifier: `appendix-${appendixIndex}`,
                 url: `${ctx.codeAppendiceTitle || 'Appendix'} ${appendixIndex}`,
                 referenceType: 'full',
-                children: [{type: 'text', value: 'code'}],
               },
             ],
             depth: 1,
@@ -35,13 +36,15 @@ module.exports = (ctx, tree) => {
 
       appendix.children.push(innerNode)
 
+      const generator = ctx.appendiceReferenceGenerator || defaultReferenceGenerator
+
       const referenceNode = {
         type: 'linkReference',
         identifier: `appendix-${appendixIndex}`,
         children: [
           {
             type: 'text',
-            value: 'code',
+            value: generator(appendixIndex),
           },
         ],
       }

--- a/packages/rebber-plugins/src/type/appendix.js
+++ b/packages/rebber-plugins/src/type/appendix.js
@@ -1,0 +1,20 @@
+/* Dependencies. */
+const all = require('rebber/dist/all')
+const clone = require('clone')
+
+/* Expose. */
+module.exports = appendixPlugin
+
+function definitionMacro (ctx, identifier, url) {
+  return `\\label{${identifier}}${url}`
+}
+
+function appendixPlugin (ctx, node) {
+  if (node.children.length === 0) {
+    return ''
+  }
+  const overriddenCtx = clone(ctx)
+  overriddenCtx.definition = definitionMacro
+  const innerText = all(overriddenCtx, node)
+  return `\\begin{appendices}\n${innerText}\n\\end{appendices}`
+}

--- a/packages/rebber-plugins/src/type/appendix.js
+++ b/packages/rebber-plugins/src/type/appendix.js
@@ -16,5 +16,5 @@ function appendixPlugin (ctx, node) {
   const overriddenCtx = clone(ctx)
   overriddenCtx.definition = definitionMacro
   const innerText = all(overriddenCtx, node)
-  return `\\begin{appendices}\n${innerText}\n\\end{appendices}`
+  return `\\begin{appendices}\n${innerText.trimEnd()}\n\\end{appendices}`
 }

--- a/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
+++ b/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
@@ -91,11 +91,11 @@ This \\\\& that.
 
 
 
-Here's a \\\\href{1}{link} with an ampersand in the URL.
+Here's a \\\\hyperref[1]{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
+Here's a link with an amersand in the link text: \\\\hyperref[2]{AT\\\\&T}.
 
 
 
@@ -888,7 +888,7 @@ breaks."
 `;
 
 exports[`rebber: remark specs case-insensitive-refs: case-insensitive-refs 1`] = `
-"\\\\href{hi}{hi}
+"\\\\hyperref[hi]{hi}
 
 
 
@@ -1117,7 +1117,7 @@ bar
 `;
 
 exports[`rebber: remark specs definition-newline: definition-newline 1`] = `
-"\\\\href{baz}{baz}: /url (
+"\\\\hyperref[baz]{baz}: /url (
 )
 
 
@@ -1138,7 +1138,7 @@ exports[`rebber: remark specs definition-newline: definition-newline 1`] = `
 
 \\\\footnote{\\\\label{baz-1-1}\\\\externalLink{/url}{/url}}
 
-\\\\href{baz}{baz}: /url 'foo"
+\\\\hyperref[baz]{baz}: /url 'foo"
 `;
 
 exports[`rebber: remark specs definition-unclosed: definition-unclosed 1`] = `
@@ -1480,13 +1480,13 @@ exports[`rebber: remark specs footnote: footnote 1`] = `
 
 \\\\footnotetext[somesamplefootnote]{\\\\label{footnote:somesamplefootnote} Here is the text of the footnote itself.}
 
-Even go to a new \\\\href{paragraph}{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
+Even go to a new \\\\hyperref[paragraph]{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
 
 
 
 \\\\footnotetext[documentdetails]{\\\\label{footnote:documentdetails} Depending on the \\\\textbf{final} form of your document, of course. See the documentation and experiment.
 
-This footnote has a second \\\\href{paragraph}{paragraph}.}
+This footnote has a second \\\\hyperref[paragraph]{paragraph}.}
 
 \\\\footnote{\\\\label{paragraph}\\\\externalLink{http://example.com}{http://example.com}}"
 `;
@@ -2546,7 +2546,7 @@ exports[`rebber: remark specs links-inline-style: links-inline-style 1`] = `
 `;
 
 exports[`rebber: remark specs links-reference-proto: links-reference-proto 1`] = `
-"A \\\\href{tostring}{primary}, \\\\href{constructor}{secondary}, and \\\\href{__proto__}{tertiary} link.
+"A \\\\hyperref[tostring]{primary}, \\\\hyperref[constructor]{secondary}, and \\\\hyperref[__proto__]{tertiary} link.
 
 
 
@@ -2558,33 +2558,33 @@ exports[`rebber: remark specs links-reference-proto: links-reference-proto 1`] =
 `;
 
 exports[`rebber: remark specs links-reference-style: links-reference-style 1`] = `
-"Foo \\\\href{1}{bar}.
+"Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{/url/}}
 
-With \\\\href{b}{embedded [brackets]}.
+With \\\\hyperref[b]{embedded [brackets]}.
 
 
 
-Indented \\\\href{once}{once}.
+Indented \\\\hyperref[once]{once}.
 
 
 
-Indented \\\\href{twice}{twice}.
+Indented \\\\hyperref[twice]{twice}.
 
 
 
-Indented \\\\href{thrice}{thrice}.
+Indented \\\\hyperref[thrice]{thrice}.
 
 
 
@@ -2610,23 +2610,23 @@ Indented [four] times.
 
 
 
-\\\\href{this}{this} should work
+\\\\hyperref[this]{this} should work
 
 
 
-So should \\\\href{this}{this}.
+So should \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
@@ -2642,11 +2642,11 @@ Nor [that].
 
 
 
-[Something in brackets like \\\\href{this}{this} should work]
+[Something in brackets like \\\\hyperref[this]{this} should work]
 
 
 
-[Same with \\\\href{this}{this}.]
+[Same with \\\\hyperref[this]{this}.]
 
 
 
@@ -2664,12 +2664,12 @@ Backslashing should suppress [this] and [this].
 
 
 
-Here's one where the \\\\href{link breaks}{link
+Here's one where the \\\\hyperref[link breaks]{link
 breaks} across lines.
 
 
 
-Here's another where the \\\\href{link breaks}{link
+Here's another where the \\\\hyperref[link breaks]{link
 breaks} across lines, but with a line-ending space.
 
 
@@ -2678,25 +2678,25 @@ breaks} across lines, but with a line-ending space.
 `;
 
 exports[`rebber: remark specs links-shortcut-references: links-shortcut-references 1`] = `
-"This is the \\\\href{simple case}{simple case}.
+"This is the \\\\hyperref[simple case]{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{/simple}}
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break}.
 
 
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{/foo}}
 
-\\\\href{that}{this} and the \\\\href{other}{other}
+\\\\hyperref[that]{this} and the \\\\hyperref[other]{other}
 
 
 
@@ -3446,7 +3446,7 @@ code();
 
 
 \\\\begin{enumerate}
-\\\\item \\\\href{foo}{foo}
+\\\\item \\\\hyperref[foo]{foo}
 \\\\end{enumerate}
 
 
@@ -3750,7 +3750,7 @@ exports[`rebber: remark specs main: main 1`] = `
 
 Just a note, I've found that I can't test my markdown parser vs others.
 For example, both markdown.js and showdown code blocks in lists wrong. They're
-also completely \\\\href{test}{inconsistent} with regards to paragraphs in list items.
+also completely \\\\hyperref[test]{inconsistent} with regards to paragraphs in list items.
 
 
 
@@ -3846,7 +3846,7 @@ exports[`rebber: remark specs markdown-documentation-basics: markdown-documentat
 
 
 This page offers a brief overview of what it's like to use Markdown.
-The \\\\href{s}{syntax page} provides complete, detailed documentation for
+The \\\\hyperref[s]{syntax page} provides complete, detailed documentation for
 every feature, but Markdown should be very easy to pick up simply by
 looking at a few examples of it in action. The examples on this page
 are written in a before/after style, showing example syntax and the
@@ -3854,14 +3854,14 @@ HTML output produced by Markdown.
 
 
 
-It's also helpful to simply try Markdown out; the \\\\href{d}{Dingus} is a
+It's also helpful to simply try Markdown out; the \\\\hyperref[d]{Dingus} is a
 web application that allows you type your own Markdown-formatted text
 and translate it to XHTML.
 
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can \\\\href{src}{see the source for it by adding '.text' to the URL}.
+can \\\\hyperref[src]{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -4362,7 +4362,7 @@ exports[`rebber: remark specs markdown-documentation-syntax: markdown-documentat
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can \\\\href{src}{see the source for it by adding '.text' to the URL}.
+can \\\\hyperref[src]{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -4384,8 +4384,8 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including \\\\href{1}{Setext}, \\\\href{2}{atx}, \\\\href{3}{Textile}, \\\\href{4}{reStructuredText},
-\\\\href{5}{Grutatext}, and \\\\href{6}{EtText} -- the single biggest source of
+filters -- including \\\\hyperref[1]{Setext}, \\\\hyperref[2]{atx}, \\\\hyperref[3]{Textile}, \\\\hyperref[4]{reStructuredText},
+\\\\hyperref[5]{Grutatext}, and \\\\hyperref[6]{EtText} -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 
 
@@ -4616,7 +4616,7 @@ end a line with two or more spaces, then type return.
 
 Yes, this takes a tad more effort to create a \\\\texttt{<br />}, but a simplistic
 \\"every line break is a \\\\texttt{<br />}\\" rule wouldn't work for Markdown.
-Markdown's email-style \\\\href{bq}{blockquoting} and multi-paragraph \\\\href{l}{list items}
+Markdown's email-style \\\\hyperref[bq]{blockquoting} and multi-paragraph \\\\hyperref[l]{list items}
 work best -- and look better -- when you format them with hard breaks.
 
 
@@ -4627,7 +4627,7 @@ work best -- and look better -- when you format them with hard breaks.
 
 <h3 id=\\"header\\">Headers</h3>
 
-Markdown supports two styles of headers, \\\\href{1}{Setext} and \\\\href{2}{atx}.
+Markdown supports two styles of headers, \\\\hyperref[1]{Setext} and \\\\hyperref[2]{atx}.
 
 
 
@@ -5847,7 +5847,7 @@ exports[`rebber: remark specs nested-references: nested-references 1`] = `
 
 
 
-\\\\href{baz}{\\\\includegraphics{https://bar.com}}
+\\\\hyperref[baz]{\\\\includegraphics{https://bar.com}}
 
 
 
@@ -5855,7 +5855,7 @@ This nested link should not work:
 
 
 
-\\\\href{baz}{[Foo][bar]}
+\\\\hyperref[baz]{[Foo][bar]}
 
 
 
@@ -5863,7 +5863,7 @@ This nested footnote not work:
 
 
 
-\\\\href{baz}{\\\\textsuperscript{\\\\ref{footnote:foo}}}
+\\\\hyperref[baz]{\\\\textsuperscript{\\\\ref{footnote:foo}}}
 
 
 
@@ -6302,7 +6302,7 @@ ccc"
 `;
 
 exports[`rebber: remark specs ref-paren: ref-paren 1`] = `
-"\\\\href{hi}{hi}
+"\\\\hyperref[hi]{hi}
 
 
 
@@ -6318,7 +6318,7 @@ exports[`rebber: remark specs reference-image-empty-alt: reference-image-empty-a
 `;
 
 exports[`rebber: remark specs reference-link-escape: reference-link-escape 1`] = `
-"[b*r*], \\\\href{b\\\\*r*}{b*r*}, \\\\href{b\\\\*r*}{b*r*}.
+"[b*r*], \\\\hyperref[b\\\\*r*]{b*r*}, \\\\hyperref[b\\\\*r*]{b*r*}.
 
 
 
@@ -6342,7 +6342,7 @@ exports[`rebber: remark specs reference-link-not-closed: reference-link-not-clos
 `;
 
 exports[`rebber: remark specs reference-link-with-angle-brackets: reference-link-with-angle-brackets 1`] = `
-"\\\\href{foo}{foo}
+"\\\\hyperref[foo]{foo}
 
 
 
@@ -6350,7 +6350,7 @@ exports[`rebber: remark specs reference-link-with-angle-brackets: reference-link
 `;
 
 exports[`rebber: remark specs reference-link-with-multiple-definitions: reference-link-with-multiple-definitions 1`] = `
-"\\\\href{foo}{foo}
+"\\\\hyperref[foo]{foo}
 
 
 
@@ -7357,7 +7357,7 @@ hello world
 
 
 
-hello \\\\href{how}{world}
+hello \\\\hyperref[how]{world}
 
 
 
@@ -13194,11 +13194,11 @@ This \\\\& that.
 
 
 
-Here's a \\\\href{1}{link} with an ampersand in the URL.
+Here's a \\\\hyperref[1]{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
+Here's a link with an amersand in the link text: \\\\hyperref[2]{AT\\\\&T}.
 
 
 
@@ -14028,7 +14028,7 @@ breaks.
 `;
 
 exports[`toLaTeX: remark specs case-insensitive-refs: case-insensitive-refs 1`] = `
-"\\\\href{hi}{hi}
+"\\\\hyperref[hi]{hi}
 
 
 
@@ -14269,7 +14269,7 @@ bar
 `;
 
 exports[`toLaTeX: remark specs definition-newline: definition-newline 1`] = `
-"\\\\href{baz}{baz}: /url (
+"\\\\hyperref[baz]{baz}: /url (
 )
 
 
@@ -14290,7 +14290,7 @@ exports[`toLaTeX: remark specs definition-newline: definition-newline 1`] = `
 
 \\\\footnote{\\\\label{baz-1-1}\\\\externalLink{/url}{/url}}
 
-\\\\href{baz}{baz}: /url 'foo
+\\\\hyperref[baz]{baz}: /url 'foo
 
 "
 `;
@@ -14672,13 +14672,13 @@ exports[`toLaTeX: remark specs footnote: footnote 1`] = `
 
 \\\\footnotetext[somesamplefootnote]{\\\\label{footnote:somesamplefootnote} Here is the text of the footnote itself.}
 
-Even go to a new \\\\href{paragraph}{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
+Even go to a new \\\\hyperref[paragraph]{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
 
 
 
 \\\\footnotetext[documentdetails]{\\\\label{footnote:documentdetails} Depending on the \\\\textbf{final} form of your document, of course. See the documentation and experiment.
 
-This footnote has a second \\\\href{paragraph}{paragraph}.}
+This footnote has a second \\\\hyperref[paragraph]{paragraph}.}
 
 \\\\footnote{\\\\label{paragraph}\\\\externalLink{http://example.com}{http://example.com}}"
 `;
@@ -15810,7 +15810,7 @@ exports[`toLaTeX: remark specs links-inline-style: links-inline-style 1`] = `
 `;
 
 exports[`toLaTeX: remark specs links-reference-proto: links-reference-proto 1`] = `
-"A \\\\href{tostring}{primary}, \\\\href{constructor}{secondary}, and \\\\href{__proto__}{tertiary} link.
+"A \\\\hyperref[tostring]{primary}, \\\\hyperref[constructor]{secondary}, and \\\\hyperref[__proto__]{tertiary} link.
 
 
 
@@ -15822,33 +15822,33 @@ exports[`toLaTeX: remark specs links-reference-proto: links-reference-proto 1`] 
 `;
 
 exports[`toLaTeX: remark specs links-reference-style: links-reference-style 1`] = `
-"Foo \\\\href{1}{bar}.
+"Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{/url/}}
 
-With \\\\href{b}{embedded [brackets]}.
+With \\\\hyperref[b]{embedded [brackets]}.
 
 
 
-Indented \\\\href{once}{once}.
+Indented \\\\hyperref[once]{once}.
 
 
 
-Indented \\\\href{twice}{twice}.
+Indented \\\\hyperref[twice]{twice}.
 
 
 
-Indented \\\\href{thrice}{thrice}.
+Indented \\\\hyperref[thrice]{thrice}.
 
 
 
@@ -15874,23 +15874,23 @@ Indented [four] times.
 
 
 
-\\\\href{this}{this} should work
+\\\\hyperref[this]{this} should work
 
 
 
-So should \\\\href{this}{this}.
+So should \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
-And \\\\href{this}{this}.
+And \\\\hyperref[this]{this}.
 
 
 
@@ -15906,11 +15906,11 @@ Nor [that].
 
 
 
-[Something in brackets like \\\\href{this}{this} should work]
+[Something in brackets like \\\\hyperref[this]{this} should work]
 
 
 
-[Same with \\\\href{this}{this}.]
+[Same with \\\\hyperref[this]{this}.]
 
 
 
@@ -15928,12 +15928,12 @@ Backslashing should suppress [this] and [this].
 
 
 
-Here's one where the \\\\href{link breaks}{link
+Here's one where the \\\\hyperref[link breaks]{link
 breaks} across lines.
 
 
 
-Here's another where the \\\\href{link breaks}{link
+Here's another where the \\\\hyperref[link breaks]{link
 breaks} across lines, but with a line-ending space.
 
 
@@ -15942,25 +15942,25 @@ breaks} across lines, but with a line-ending space.
 `;
 
 exports[`toLaTeX: remark specs links-shortcut-references: links-shortcut-references 1`] = `
-"This is the \\\\href{simple case}{simple case}.
+"This is the \\\\hyperref[simple case]{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{/simple}}
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break}.
 
 
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{/foo}}
 
-\\\\href{that}{this} and the \\\\href{other}{other}
+\\\\hyperref[that]{this} and the \\\\hyperref[other]{other}
 
 
 
@@ -16776,7 +16776,7 @@ code();
 
 
 \\\\begin{enumerate}
-\\\\item \\\\href{foo}{foo}
+\\\\item \\\\hyperref[foo]{foo}
 \\\\end{enumerate}
 
 
@@ -17089,7 +17089,7 @@ exports[`toLaTeX: remark specs main: main 1`] = `
 
 Just a note, I've found that I can't test my markdown parser vs others.
 For example, both markdown.js and showdown code blocks in lists wrong. They're
-also completely \\\\href{test}{inconsistent} with regards to paragraphs in list items.
+also completely \\\\hyperref[test]{inconsistent} with regards to paragraphs in list items.
 
 
 
@@ -17187,7 +17187,7 @@ exports[`toLaTeX: remark specs markdown-documentation-basics: markdown-documenta
 
 
 This page offers a brief overview of what it's like to use Markdown.
-The \\\\href{s}{syntax page} provides complete, detailed documentation for
+The \\\\hyperref[s]{syntax page} provides complete, detailed documentation for
 every feature, but Markdown should be very easy to pick up simply by
 looking at a few examples of it in action. The examples on this page
 are written in a before/after style, showing example syntax and the
@@ -17195,14 +17195,14 @@ HTML output produced by Markdown.
 
 
 
-It's also helpful to simply try Markdown out; the \\\\href{d}{Dingus} is a
+It's also helpful to simply try Markdown out; the \\\\hyperref[d]{Dingus} is a
 web application that allows you type your own Markdown-formatted text
 and translate it to XHTML.
 
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can \\\\href{src}{see the source for it by adding '.text' to the URL}.
+can \\\\hyperref[src]{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -17705,7 +17705,7 @@ exports[`toLaTeX: remark specs markdown-documentation-syntax: markdown-documenta
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can \\\\href{src}{see the source for it by adding '.text' to the URL}.
+can \\\\hyperref[src]{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -17727,8 +17727,8 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including \\\\href{1}{Setext}, \\\\href{2}{atx}, \\\\href{3}{Textile}, \\\\href{4}{reStructuredText},
-\\\\href{5}{Grutatext}, and \\\\href{6}{EtText} -- the single biggest source of
+filters -- including \\\\hyperref[1]{Setext}, \\\\hyperref[2]{atx}, \\\\hyperref[3]{Textile}, \\\\hyperref[4]{reStructuredText},
+\\\\hyperref[5]{Grutatext}, and \\\\hyperref[6]{EtText} -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 
 
@@ -17959,7 +17959,7 @@ end a line with two or more spaces, then type return.
 
 Yes, this takes a tad more effort to create a \\\\texttt{<br />}, but a simplistic
 \\"every line break is a \\\\texttt{<br />}\\" rule wouldn't work for Markdown.
-Markdown's email-style \\\\href{bq}{blockquoting} and multi-paragraph \\\\href{l}{list items}
+Markdown's email-style \\\\hyperref[bq]{blockquoting} and multi-paragraph \\\\hyperref[l]{list items}
 work best -- and look better -- when you format them with hard breaks.
 
 
@@ -17970,7 +17970,7 @@ work best -- and look better -- when you format them with hard breaks.
 
 <h3 id=\\"header\\">Headers</h3>
 
-Markdown supports two styles of headers, \\\\href{1}{Setext} and \\\\href{2}{atx}.
+Markdown supports two styles of headers, \\\\hyperref[1]{Setext} and \\\\hyperref[2]{atx}.
 
 
 
@@ -19199,7 +19199,7 @@ exports[`toLaTeX: remark specs nested-references: nested-references 1`] = `
 
 
 
-\\\\href{baz}{\\\\includegraphics{https://bar.com}}
+\\\\hyperref[baz]{\\\\includegraphics{https://bar.com}}
 
 
 
@@ -19207,7 +19207,7 @@ This nested link should not work:
 
 
 
-\\\\href{baz}{[Foo][bar]}
+\\\\hyperref[baz]{[Foo][bar]}
 
 
 
@@ -19215,7 +19215,7 @@ This nested footnote not work:
 
 
 
-\\\\href{baz}{\\\\textsuperscript{\\\\ref{footnote:foo}}}
+\\\\hyperref[baz]{\\\\textsuperscript{\\\\ref{footnote:foo}}}
 
 
 
@@ -19670,7 +19670,7 @@ ccc
 `;
 
 exports[`toLaTeX: remark specs ref-paren: ref-paren 1`] = `
-"\\\\href{hi}{hi}
+"\\\\hyperref[hi]{hi}
 
 
 
@@ -19686,7 +19686,7 @@ exports[`toLaTeX: remark specs reference-image-empty-alt: reference-image-empty-
 `;
 
 exports[`toLaTeX: remark specs reference-link-escape: reference-link-escape 1`] = `
-"[b*r*], \\\\href{b\\\\*r*}{b*r*}, \\\\href{b\\\\*r*}{b*r*}.
+"[b*r*], \\\\hyperref[b\\\\*r*]{b*r*}, \\\\hyperref[b\\\\*r*]{b*r*}.
 
 
 
@@ -19712,7 +19712,7 @@ exports[`toLaTeX: remark specs reference-link-not-closed: reference-link-not-clo
 `;
 
 exports[`toLaTeX: remark specs reference-link-with-angle-brackets: reference-link-with-angle-brackets 1`] = `
-"\\\\href{foo}{foo}
+"\\\\hyperref[foo]{foo}
 
 
 
@@ -19720,7 +19720,7 @@ exports[`toLaTeX: remark specs reference-link-with-angle-brackets: reference-lin
 `;
 
 exports[`toLaTeX: remark specs reference-link-with-multiple-definitions: reference-link-with-multiple-definitions 1`] = `
-"\\\\href{foo}{foo}
+"\\\\hyperref[foo]{foo}
 
 
 
@@ -20765,7 +20765,7 @@ hello world
 
 
 
-hello \\\\href{how}{world}
+hello \\\\hyperref[how]{world}
 
 
 

--- a/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
+++ b/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
@@ -91,11 +91,11 @@ This \\\\& that.
 
 
 
-Here's a link\\\\ref{1} with an ampersand in the URL.
+Here's a \\\\href{1}{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: AT\\\\&T\\\\ref{2}.
+Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
 
 
 
@@ -888,7 +888,7 @@ breaks."
 `;
 
 exports[`rebber: remark specs case-insensitive-refs: case-insensitive-refs 1`] = `
-"hi\\\\ref{hi}
+"\\\\href{hi}{hi}
 
 
 
@@ -1117,7 +1117,7 @@ bar
 `;
 
 exports[`rebber: remark specs definition-newline: definition-newline 1`] = `
-"baz\\\\ref{baz}: /url (
+"\\\\href{baz}{baz}: /url (
 )
 
 
@@ -1138,7 +1138,7 @@ exports[`rebber: remark specs definition-newline: definition-newline 1`] = `
 
 \\\\footnote{\\\\label{baz-1-1}\\\\externalLink{/url}{/url}}
 
-baz\\\\ref{baz}: /url 'foo"
+\\\\href{baz}{baz}: /url 'foo"
 `;
 
 exports[`rebber: remark specs definition-unclosed: definition-unclosed 1`] = `
@@ -1480,13 +1480,13 @@ exports[`rebber: remark specs footnote: footnote 1`] = `
 
 \\\\footnotetext[somesamplefootnote]{\\\\label{footnote:somesamplefootnote} Here is the text of the footnote itself.}
 
-Even go to a new paragraph\\\\ref{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
+Even go to a new \\\\href{paragraph}{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
 
 
 
 \\\\footnotetext[documentdetails]{\\\\label{footnote:documentdetails} Depending on the \\\\textbf{final} form of your document, of course. See the documentation and experiment.
 
-This footnote has a second paragraph\\\\ref{paragraph}.}
+This footnote has a second \\\\href{paragraph}{paragraph}.}
 
 \\\\footnote{\\\\label{paragraph}\\\\externalLink{http://example.com}{http://example.com}}"
 `;
@@ -2546,7 +2546,7 @@ exports[`rebber: remark specs links-inline-style: links-inline-style 1`] = `
 `;
 
 exports[`rebber: remark specs links-reference-proto: links-reference-proto 1`] = `
-"A primary\\\\ref{tostring}, secondary\\\\ref{constructor}, and tertiary\\\\ref{__proto__} link.
+"A \\\\href{tostring}{primary}, \\\\href{constructor}{secondary}, and \\\\href{__proto__}{tertiary} link.
 
 
 
@@ -2558,33 +2558,33 @@ exports[`rebber: remark specs links-reference-proto: links-reference-proto 1`] =
 `;
 
 exports[`rebber: remark specs links-reference-style: links-reference-style 1`] = `
-"Foo bar\\\\ref{1}.
+"Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{/url/}}
 
-With embedded [brackets]\\\\ref{b}.
+With \\\\href{b}{embedded [brackets]}.
 
 
 
-Indented once\\\\ref{once}.
+Indented \\\\href{once}{once}.
 
 
 
-Indented twice\\\\ref{twice}.
+Indented \\\\href{twice}{twice}.
 
 
 
-Indented thrice\\\\ref{thrice}.
+Indented \\\\href{thrice}{thrice}.
 
 
 
@@ -2610,23 +2610,23 @@ Indented [four] times.
 
 
 
-this\\\\ref{this} should work
+\\\\href{this}{this} should work
 
 
 
-So should this\\\\ref{this}.
+So should \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
@@ -2642,11 +2642,11 @@ Nor [that].
 
 
 
-[Something in brackets like this\\\\ref{this} should work]
+[Something in brackets like \\\\href{this}{this} should work]
 
 
 
-[Same with this\\\\ref{this}.]
+[Same with \\\\href{this}{this}.]
 
 
 
@@ -2664,13 +2664,13 @@ Backslashing should suppress [this] and [this].
 
 
 
-Here's one where the link
-breaks\\\\ref{link breaks} across lines.
+Here's one where the \\\\href{link breaks}{link
+breaks} across lines.
 
 
 
-Here's another where the link
-breaks\\\\ref{link breaks} across lines, but with a line-ending space.
+Here's another where the \\\\href{link breaks}{link
+breaks} across lines, but with a line-ending space.
 
 
 
@@ -2678,25 +2678,25 @@ breaks\\\\ref{link breaks} across lines, but with a line-ending space.
 `;
 
 exports[`rebber: remark specs links-shortcut-references: links-shortcut-references 1`] = `
-"This is the simple case\\\\ref{simple case}.
+"This is the \\\\href{simple case}{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{/simple}}
 
-This one has a line
-break\\\\ref{line break}.
+This one has a \\\\href{line break}{line
+break}.
 
 
 
-This one has a line
-break\\\\ref{line break} with a line-ending space.
+This one has a \\\\href{line break}{line
+break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{/foo}}
 
-this\\\\ref{that} and the other\\\\ref{other}
+\\\\href{that}{this} and the \\\\href{other}{other}
 
 
 
@@ -3446,7 +3446,7 @@ code();
 
 
 \\\\begin{enumerate}
-\\\\item foo\\\\ref{foo}
+\\\\item \\\\href{foo}{foo}
 \\\\end{enumerate}
 
 
@@ -3750,7 +3750,7 @@ exports[`rebber: remark specs main: main 1`] = `
 
 Just a note, I've found that I can't test my markdown parser vs others.
 For example, both markdown.js and showdown code blocks in lists wrong. They're
-also completely inconsistent\\\\ref{test} with regards to paragraphs in list items.
+also completely \\\\href{test}{inconsistent} with regards to paragraphs in list items.
 
 
 
@@ -3846,7 +3846,7 @@ exports[`rebber: remark specs markdown-documentation-basics: markdown-documentat
 
 
 This page offers a brief overview of what it's like to use Markdown.
-The syntax page\\\\ref{s} provides complete, detailed documentation for
+The \\\\href{s}{syntax page} provides complete, detailed documentation for
 every feature, but Markdown should be very easy to pick up simply by
 looking at a few examples of it in action. The examples on this page
 are written in a before/after style, showing example syntax and the
@@ -3854,14 +3854,14 @@ HTML output produced by Markdown.
 
 
 
-It's also helpful to simply try Markdown out; the Dingus\\\\ref{d} is a
+It's also helpful to simply try Markdown out; the \\\\href{d}{Dingus} is a
 web application that allows you type your own Markdown-formatted text
 and translate it to XHTML.
 
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can see the source for it by adding '.text' to the URL\\\\ref{src}.
+can \\\\href{src}{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -4362,7 +4362,7 @@ exports[`rebber: remark specs markdown-documentation-syntax: markdown-documentat
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can see the source for it by adding '.text' to the URL\\\\ref{src}.
+can \\\\href{src}{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -4384,8 +4384,8 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including Setext\\\\ref{1}, atx\\\\ref{2}, Textile\\\\ref{3}, reStructuredText\\\\ref{4},
-Grutatext\\\\ref{5}, and EtText\\\\ref{6} -- the single biggest source of
+filters -- including \\\\href{1}{Setext}, \\\\href{2}{atx}, \\\\href{3}{Textile}, \\\\href{4}{reStructuredText},
+\\\\href{5}{Grutatext}, and \\\\href{6}{EtText} -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 
 
@@ -4616,7 +4616,7 @@ end a line with two or more spaces, then type return.
 
 Yes, this takes a tad more effort to create a \\\\texttt{<br />}, but a simplistic
 \\"every line break is a \\\\texttt{<br />}\\" rule wouldn't work for Markdown.
-Markdown's email-style blockquoting\\\\ref{bq} and multi-paragraph list items\\\\ref{l}
+Markdown's email-style \\\\href{bq}{blockquoting} and multi-paragraph \\\\href{l}{list items}
 work best -- and look better -- when you format them with hard breaks.
 
 
@@ -4627,7 +4627,7 @@ work best -- and look better -- when you format them with hard breaks.
 
 <h3 id=\\"header\\">Headers</h3>
 
-Markdown supports two styles of headers, Setext\\\\ref{1} and atx\\\\ref{2}.
+Markdown supports two styles of headers, \\\\href{1}{Setext} and \\\\href{2}{atx}.
 
 
 
@@ -5847,7 +5847,7 @@ exports[`rebber: remark specs nested-references: nested-references 1`] = `
 
 
 
-\\\\includegraphics{https://bar.com}\\\\ref{baz}
+\\\\href{baz}{\\\\includegraphics{https://bar.com}}
 
 
 
@@ -5855,7 +5855,7 @@ This nested link should not work:
 
 
 
-[Foo][bar]\\\\ref{baz}
+\\\\href{baz}{[Foo][bar]}
 
 
 
@@ -5863,7 +5863,7 @@ This nested footnote not work:
 
 
 
-\\\\textsuperscript{\\\\ref{footnote:foo}}\\\\ref{baz}
+\\\\href{baz}{\\\\textsuperscript{\\\\ref{footnote:foo}}}
 
 
 
@@ -6302,7 +6302,7 @@ ccc"
 `;
 
 exports[`rebber: remark specs ref-paren: ref-paren 1`] = `
-"hi\\\\ref{hi}
+"\\\\href{hi}{hi}
 
 
 
@@ -6318,7 +6318,7 @@ exports[`rebber: remark specs reference-image-empty-alt: reference-image-empty-a
 `;
 
 exports[`rebber: remark specs reference-link-escape: reference-link-escape 1`] = `
-"[b*r*], b*r*\\\\ref{b\\\\*r*}, b*r*\\\\ref{b\\\\*r*}.
+"[b*r*], \\\\href{b\\\\*r*}{b*r*}, \\\\href{b\\\\*r*}{b*r*}.
 
 
 
@@ -6342,7 +6342,7 @@ exports[`rebber: remark specs reference-link-not-closed: reference-link-not-clos
 `;
 
 exports[`rebber: remark specs reference-link-with-angle-brackets: reference-link-with-angle-brackets 1`] = `
-"foo\\\\ref{foo}
+"\\\\href{foo}{foo}
 
 
 
@@ -6350,7 +6350,7 @@ exports[`rebber: remark specs reference-link-with-angle-brackets: reference-link
 `;
 
 exports[`rebber: remark specs reference-link-with-multiple-definitions: reference-link-with-multiple-definitions 1`] = `
-"foo\\\\ref{foo}
+"\\\\href{foo}{foo}
 
 
 
@@ -7357,7 +7357,7 @@ hello world
 
 
 
-hello world\\\\ref{how}
+hello \\\\href{how}{world}
 
 
 
@@ -13194,11 +13194,11 @@ This \\\\& that.
 
 
 
-Here's a link\\\\ref{1} with an ampersand in the URL.
+Here's a \\\\href{1}{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: AT\\\\&T\\\\ref{2}.
+Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
 
 
 
@@ -14028,7 +14028,7 @@ breaks.
 `;
 
 exports[`toLaTeX: remark specs case-insensitive-refs: case-insensitive-refs 1`] = `
-"hi\\\\ref{hi}
+"\\\\href{hi}{hi}
 
 
 
@@ -14269,7 +14269,7 @@ bar
 `;
 
 exports[`toLaTeX: remark specs definition-newline: definition-newline 1`] = `
-"baz\\\\ref{baz}: /url (
+"\\\\href{baz}{baz}: /url (
 )
 
 
@@ -14290,7 +14290,7 @@ exports[`toLaTeX: remark specs definition-newline: definition-newline 1`] = `
 
 \\\\footnote{\\\\label{baz-1-1}\\\\externalLink{/url}{/url}}
 
-baz\\\\ref{baz}: /url 'foo
+\\\\href{baz}{baz}: /url 'foo
 
 "
 `;
@@ -14672,13 +14672,13 @@ exports[`toLaTeX: remark specs footnote: footnote 1`] = `
 
 \\\\footnotetext[somesamplefootnote]{\\\\label{footnote:somesamplefootnote} Here is the text of the footnote itself.}
 
-Even go to a new paragraph\\\\ref{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
+Even go to a new \\\\href{paragraph}{paragraph} and the footnotes will go to the bottom of the document\\\\textsuperscript{\\\\ref{footnote:documentdetails}}.
 
 
 
 \\\\footnotetext[documentdetails]{\\\\label{footnote:documentdetails} Depending on the \\\\textbf{final} form of your document, of course. See the documentation and experiment.
 
-This footnote has a second paragraph\\\\ref{paragraph}.}
+This footnote has a second \\\\href{paragraph}{paragraph}.}
 
 \\\\footnote{\\\\label{paragraph}\\\\externalLink{http://example.com}{http://example.com}}"
 `;
@@ -15810,7 +15810,7 @@ exports[`toLaTeX: remark specs links-inline-style: links-inline-style 1`] = `
 `;
 
 exports[`toLaTeX: remark specs links-reference-proto: links-reference-proto 1`] = `
-"A primary\\\\ref{tostring}, secondary\\\\ref{constructor}, and tertiary\\\\ref{__proto__} link.
+"A \\\\href{tostring}{primary}, \\\\href{constructor}{secondary}, and \\\\href{__proto__}{tertiary} link.
 
 
 
@@ -15822,33 +15822,33 @@ exports[`toLaTeX: remark specs links-reference-proto: links-reference-proto 1`] 
 `;
 
 exports[`toLaTeX: remark specs links-reference-style: links-reference-style 1`] = `
-"Foo bar\\\\ref{1}.
+"Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{/url/}}
 
-With embedded [brackets]\\\\ref{b}.
+With \\\\href{b}{embedded [brackets]}.
 
 
 
-Indented once\\\\ref{once}.
+Indented \\\\href{once}{once}.
 
 
 
-Indented twice\\\\ref{twice}.
+Indented \\\\href{twice}{twice}.
 
 
 
-Indented thrice\\\\ref{thrice}.
+Indented \\\\href{thrice}{thrice}.
 
 
 
@@ -15874,23 +15874,23 @@ Indented [four] times.
 
 
 
-this\\\\ref{this} should work
+\\\\href{this}{this} should work
 
 
 
-So should this\\\\ref{this}.
+So should \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
-And this\\\\ref{this}.
+And \\\\href{this}{this}.
 
 
 
@@ -15906,11 +15906,11 @@ Nor [that].
 
 
 
-[Something in brackets like this\\\\ref{this} should work]
+[Something in brackets like \\\\href{this}{this} should work]
 
 
 
-[Same with this\\\\ref{this}.]
+[Same with \\\\href{this}{this}.]
 
 
 
@@ -15928,13 +15928,13 @@ Backslashing should suppress [this] and [this].
 
 
 
-Here's one where the link
-breaks\\\\ref{link breaks} across lines.
+Here's one where the \\\\href{link breaks}{link
+breaks} across lines.
 
 
 
-Here's another where the link
-breaks\\\\ref{link breaks} across lines, but with a line-ending space.
+Here's another where the \\\\href{link breaks}{link
+breaks} across lines, but with a line-ending space.
 
 
 
@@ -15942,25 +15942,25 @@ breaks\\\\ref{link breaks} across lines, but with a line-ending space.
 `;
 
 exports[`toLaTeX: remark specs links-shortcut-references: links-shortcut-references 1`] = `
-"This is the simple case\\\\ref{simple case}.
+"This is the \\\\href{simple case}{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{/simple}}
 
-This one has a line
-break\\\\ref{line break}.
+This one has a \\\\href{line break}{line
+break}.
 
 
 
-This one has a line
-break\\\\ref{line break} with a line-ending space.
+This one has a \\\\href{line break}{line
+break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{/foo}}
 
-this\\\\ref{that} and the other\\\\ref{other}
+\\\\href{that}{this} and the \\\\href{other}{other}
 
 
 
@@ -16776,7 +16776,7 @@ code();
 
 
 \\\\begin{enumerate}
-\\\\item foo\\\\ref{foo}
+\\\\item \\\\href{foo}{foo}
 \\\\end{enumerate}
 
 
@@ -17089,7 +17089,7 @@ exports[`toLaTeX: remark specs main: main 1`] = `
 
 Just a note, I've found that I can't test my markdown parser vs others.
 For example, both markdown.js and showdown code blocks in lists wrong. They're
-also completely inconsistent\\\\ref{test} with regards to paragraphs in list items.
+also completely \\\\href{test}{inconsistent} with regards to paragraphs in list items.
 
 
 
@@ -17187,7 +17187,7 @@ exports[`toLaTeX: remark specs markdown-documentation-basics: markdown-documenta
 
 
 This page offers a brief overview of what it's like to use Markdown.
-The syntax page\\\\ref{s} provides complete, detailed documentation for
+The \\\\href{s}{syntax page} provides complete, detailed documentation for
 every feature, but Markdown should be very easy to pick up simply by
 looking at a few examples of it in action. The examples on this page
 are written in a before/after style, showing example syntax and the
@@ -17195,14 +17195,14 @@ HTML output produced by Markdown.
 
 
 
-It's also helpful to simply try Markdown out; the Dingus\\\\ref{d} is a
+It's also helpful to simply try Markdown out; the \\\\href{d}{Dingus} is a
 web application that allows you type your own Markdown-formatted text
 and translate it to XHTML.
 
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can see the source for it by adding '.text' to the URL\\\\ref{src}.
+can \\\\href{src}{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -17705,7 +17705,7 @@ exports[`toLaTeX: remark specs markdown-documentation-syntax: markdown-documenta
 
 
 \\\\textbf{Note:} This document is itself written using Markdown; you
-can see the source for it by adding '.text' to the URL\\\\ref{src}.
+can \\\\href{src}{see the source for it by adding '.text' to the URL}.
 
 
 
@@ -17727,8 +17727,8 @@ Readability, however, is emphasized above all else. A Markdown-formatted
 document should be publishable as-is, as plain text, without looking
 like it's been marked up with tags or formatting instructions. While
 Markdown's syntax has been influenced by several existing text-to-HTML
-filters -- including Setext\\\\ref{1}, atx\\\\ref{2}, Textile\\\\ref{3}, reStructuredText\\\\ref{4},
-Grutatext\\\\ref{5}, and EtText\\\\ref{6} -- the single biggest source of
+filters -- including \\\\href{1}{Setext}, \\\\href{2}{atx}, \\\\href{3}{Textile}, \\\\href{4}{reStructuredText},
+\\\\href{5}{Grutatext}, and \\\\href{6}{EtText} -- the single biggest source of
 inspiration for Markdown's syntax is the format of plain text email.
 
 
@@ -17959,7 +17959,7 @@ end a line with two or more spaces, then type return.
 
 Yes, this takes a tad more effort to create a \\\\texttt{<br />}, but a simplistic
 \\"every line break is a \\\\texttt{<br />}\\" rule wouldn't work for Markdown.
-Markdown's email-style blockquoting\\\\ref{bq} and multi-paragraph list items\\\\ref{l}
+Markdown's email-style \\\\href{bq}{blockquoting} and multi-paragraph \\\\href{l}{list items}
 work best -- and look better -- when you format them with hard breaks.
 
 
@@ -17970,7 +17970,7 @@ work best -- and look better -- when you format them with hard breaks.
 
 <h3 id=\\"header\\">Headers</h3>
 
-Markdown supports two styles of headers, Setext\\\\ref{1} and atx\\\\ref{2}.
+Markdown supports two styles of headers, \\\\href{1}{Setext} and \\\\href{2}{atx}.
 
 
 
@@ -19199,7 +19199,7 @@ exports[`toLaTeX: remark specs nested-references: nested-references 1`] = `
 
 
 
-\\\\includegraphics{https://bar.com}\\\\ref{baz}
+\\\\href{baz}{\\\\includegraphics{https://bar.com}}
 
 
 
@@ -19207,7 +19207,7 @@ This nested link should not work:
 
 
 
-[Foo][bar]\\\\ref{baz}
+\\\\href{baz}{[Foo][bar]}
 
 
 
@@ -19215,7 +19215,7 @@ This nested footnote not work:
 
 
 
-\\\\textsuperscript{\\\\ref{footnote:foo}}\\\\ref{baz}
+\\\\href{baz}{\\\\textsuperscript{\\\\ref{footnote:foo}}}
 
 
 
@@ -19670,7 +19670,7 @@ ccc
 `;
 
 exports[`toLaTeX: remark specs ref-paren: ref-paren 1`] = `
-"hi\\\\ref{hi}
+"\\\\href{hi}{hi}
 
 
 
@@ -19686,7 +19686,7 @@ exports[`toLaTeX: remark specs reference-image-empty-alt: reference-image-empty-
 `;
 
 exports[`toLaTeX: remark specs reference-link-escape: reference-link-escape 1`] = `
-"[b*r*], b*r*\\\\ref{b\\\\*r*}, b*r*\\\\ref{b\\\\*r*}.
+"[b*r*], \\\\href{b\\\\*r*}{b*r*}, \\\\href{b\\\\*r*}{b*r*}.
 
 
 
@@ -19712,7 +19712,7 @@ exports[`toLaTeX: remark specs reference-link-not-closed: reference-link-not-clo
 `;
 
 exports[`toLaTeX: remark specs reference-link-with-angle-brackets: reference-link-with-angle-brackets 1`] = `
-"foo\\\\ref{foo}
+"\\\\href{foo}{foo}
 
 
 
@@ -19720,7 +19720,7 @@ exports[`toLaTeX: remark specs reference-link-with-angle-brackets: reference-lin
 `;
 
 exports[`toLaTeX: remark specs reference-link-with-multiple-definitions: reference-link-with-multiple-definitions 1`] = `
-"foo\\\\ref{foo}
+"\\\\href{foo}{foo}
 
 
 
@@ -20765,7 +20765,7 @@ hello world
 
 
 
-hello world\\\\ref{how}
+hello \\\\href{how}{world}
 
 
 

--- a/packages/rebber/dist/escaper.js
+++ b/packages/rebber/dist/escaper.js
@@ -22,8 +22,9 @@ var defaultEscapes = {
   '{': '\\{',
   '}': '\\}',
   '~': '\\textasciitilde{}'
+  /* Encode special characters in `value`. */
+
 };
-/* Encode special characters in `value`. */
 
 function encode(value) {
   var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};

--- a/packages/rebber/dist/index.js
+++ b/packages/rebber/dist/index.js
@@ -13,12 +13,14 @@ var preprocess = require('./preprocessors');
 
 module.exports = stringify;
 module.exports.toLaTeX = toLaTeX;
-/* Stringify the given MDAST node. */
 
 function toLaTeX(tree) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  /* Stringify the given MDAST node. */
+  preprocess(options, tree); // resolve definition after preprocess because this step can create new identifiers
+
   options.definitions = definitions(tree, options);
-  preprocess(options, tree);
   return one(options, tree, undefined, undefined);
 }
 /* Compile MDAST tree using toLaTeX */

--- a/packages/rebber/dist/preprocessors/referenceVisitors.js
+++ b/packages/rebber/dist/preprocessors/referenceVisitors.js
@@ -26,6 +26,9 @@ module.exports = function () {
         node.title = '';
         node.url = state[node.identifier];
       };
+    },
+    addIdentifier: function addIdentifier(identifier, content) {
+      state[identifier] = content;
     }
   };
 };

--- a/packages/rebber/dist/types/linkReference.js
+++ b/packages/rebber/dist/types/linkReference.js
@@ -3,7 +3,7 @@
 module.exports = linkReference;
 
 var defaultMacro = function defaultMacro(reference, inner) {
-  return "\\href{".concat(reference, "}{").concat(inner, "}");
+  return "\\hyperref[".concat(reference, "]{").concat(inner, "}");
 };
 
 function linkReference(ctx, node) {

--- a/packages/rebber/dist/types/linkReference.js
+++ b/packages/rebber/dist/types/linkReference.js
@@ -3,7 +3,7 @@
 module.exports = linkReference;
 
 var defaultMacro = function defaultMacro(reference, inner) {
-  return "".concat(inner, "\\ref{").concat(reference, "}");
+  return "\\href{".concat(reference, "}{").concat(inner, "}");
 };
 
 function linkReference(ctx, node) {

--- a/packages/rebber/src/index.js
+++ b/packages/rebber/src/index.js
@@ -8,11 +8,11 @@ const preprocess = require('./preprocessors')
 module.exports = stringify
 module.exports.toLaTeX = toLaTeX
 
-/* Stringify the given MDAST node. */
 function toLaTeX (tree, options = {}) {
-  options.definitions = definitions(tree, options)
-
+  /* Stringify the given MDAST node. */
   preprocess(options, tree)
+  // resolve definition after preprocess because this step can create new identifiers
+  options.definitions = definitions(tree, options)
   return one(options, tree, undefined, undefined)
 }
 

--- a/packages/rebber/src/preprocessors/referenceVisitors.js
+++ b/packages/rebber/src/preprocessors/referenceVisitors.js
@@ -25,5 +25,8 @@ module.exports = () => {
         node.url = state[node.identifier]
       }
     },
+    addIdentifier (identifier, content) {
+      state[identifier] = content
+    },
   }
 }

--- a/packages/rebber/src/types/linkReference.js
+++ b/packages/rebber/src/types/linkReference.js
@@ -1,6 +1,6 @@
 module.exports = linkReference
 
-const defaultMacro = (reference, inner) => `\\href{${reference}}{${inner}}`
+const defaultMacro = (reference, inner) => `\\hyperref[${reference}]{${inner}}`
 
 function linkReference (ctx, node) {
   const macro = ctx.linkReference ? ctx.linkReference : defaultMacro

--- a/packages/rebber/src/types/linkReference.js
+++ b/packages/rebber/src/types/linkReference.js
@@ -1,6 +1,6 @@
 module.exports = linkReference
 
-const defaultMacro = (reference, inner) => `${inner}\\ref{${reference}}`
+const defaultMacro = (reference, inner) => `\\href{${reference}}{${inner}}`
 
 function linkReference (ctx, node) {
   const macro = ctx.linkReference ? ctx.linkReference : defaultMacro

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -115,11 +115,11 @@ exports[`codes in notes 1`] = `
 
 \\\\footnotetext[1]{\\\\label{footnote:1} test
 
-\\\\hyperref[appendix-1]{code}}
+\\\\hyperref[appendix-1]{Annexe de code 1}}
 
 \\\\footnotetext[2]{\\\\label{footnote:2} test
 
-\\\\hyperref[appendix-3]{code}}
+\\\\hyperref[appendix-3]{Annexe de code 3}}
 
 \\\\begin{appendices}
 \\\\levelOneTitle{\\\\label{appendix-1}Annexes 1}
@@ -133,8 +133,6 @@ exports[`codes in notes 1`] = `
 \\\\begin{CodeBlock}{javascript}
 console.log('hello')
 \\\\end{CodeBlock}
-
-
 \\\\end{appendices}"
 `;
 
@@ -552,7 +550,7 @@ space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{Annexe de code 1} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
@@ -562,8 +560,6 @@ block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
 \\\\begin{CodeBlock}{python}
 print('bla')
 \\\\end{CodeBlock}
-
-
 \\\\end{appendices}"
 `;
 
@@ -575,9 +571,9 @@ exports[`mix-5 1`] = `
 `;
 
 exports[`mix-6 1`] = `
-"\\\\iframe{https://www.youtube.com/embed/8TQIvdFl4aU?feature=oembed}[Video][a caption]
+"\\\\externalLink{https://www.youtube.com/watch?v=8TQIvdFl4aU}{https://www.youtube.com/watch?v=8TQIvdFl4aU}
 
-\\\\iframe{https://www.youtube.com/embed/8TQIvdFl4aU?feature=oembed}[Video][]
+\\\\externalLink{https://www.youtube.com/watch?v=8TQIvdFl4aU}{https://www.youtube.com/watch?v=8TQIvdFl4aU}
 
 no caption"
 `;

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -108,6 +108,36 @@ print('bla')
 \\\\captionof{listing}{With Source}"
 `;
 
+exports[`codes in notes 1`] = `
+"hello \\\\textsuperscript{\\\\ref{footnote:1}}\\\\textsuperscript{\\\\ref{footnote:2}}
+
+
+
+\\\\footnotetext[1]{\\\\label{footnote:1} test
+
+\\\\href{appendix-1}{code}}
+
+\\\\footnotetext[2]{\\\\label{footnote:2} test
+
+\\\\href{appendix-3}{code}}
+
+\\\\begin{appendices}
+\\\\label{appendix-1}appendix 1
+
+\\\\begin{CodeBlock}{javascript}
+ console.log('hello')
+\\\\end{CodeBlock}
+
+\\\\label{appendix-3}appendix 3
+
+\\\\begin{CodeBlock}{javascript}
+console.log('hello')
+\\\\end{CodeBlock}
+
+
+\\\\end{appendices}"
+`;
+
 exports[`custom-blocks 1`] = `
 "\\\\begin{Information}
 info
@@ -522,17 +552,19 @@ space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
-block & [] \\\\\\\\ \\\\hline
+block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 
-\\\\levelOneTitle{Annexes}
+\\\\begin{appendices}
+\\\\label{appendix-1}appendix 1
 
-
-\\\\footnote{\\\\label{appendix-1}}
 \\\\begin{CodeBlock}{python}
 print('bla')
-\\\\end{CodeBlock}"
+\\\\end{CodeBlock}
+
+
+\\\\end{appendices}"
 `;
 
 exports[`mix-5 1`] = `

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -122,13 +122,13 @@ exports[`codes in notes 1`] = `
 \\\\href{appendix-3}{code}}
 
 \\\\begin{appendices}
-\\\\label{appendix-1}appendix 1
+\\\\levelOneTitle{\\\\label{appendix-1}Annexes 1}
 
 \\\\begin{CodeBlock}{javascript}
  console.log('hello')
 \\\\end{CodeBlock}
 
-\\\\label{appendix-3}appendix 3
+\\\\levelOneTitle{\\\\label{appendix-3}Annexes 3}
 
 \\\\begin{CodeBlock}{javascript}
 console.log('hello')
@@ -557,7 +557,7 @@ block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
 
 
 \\\\begin{appendices}
-\\\\label{appendix-1}appendix 1
+\\\\levelOneTitle{\\\\label{appendix-1}Annexes 1}
 
 \\\\begin{CodeBlock}{python}
 print('bla')

--- a/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex.tests.js.snap
@@ -115,11 +115,11 @@ exports[`codes in notes 1`] = `
 
 \\\\footnotetext[1]{\\\\label{footnote:1} test
 
-\\\\href{appendix-1}{code}}
+\\\\hyperref[appendix-1]{code}}
 
 \\\\footnotetext[2]{\\\\label{footnote:2} test
 
-\\\\href{appendix-3}{code}}
+\\\\hyperref[appendix-3]{code}}
 
 \\\\begin{appendices}
 \\\\levelOneTitle{\\\\label{appendix-1}Annexes 1}
@@ -552,7 +552,7 @@ space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \
 title & code \\\\\\\\ \\\\hline
 \\\\rowfont[l]{}
 inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
-block & \\\\href{appendix-1}{code} \\\\\\\\ \\\\hline
+block & \\\\hyperref[appendix-1]{code} \\\\\\\\ \\\\hline
 \\\\end{longtabu}
 
 

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -21,11 +21,11 @@ This \\\\& that.
 
 
 
-Here's a \\\\href{1}{link} with an ampersand in the URL.
+Here's a \\\\hyperref[1]{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
+Here's a link with an amersand in the link text: \\\\hyperref[2]{AT\\\\&T}.
 
 
 
@@ -636,33 +636,33 @@ exports[`#basic properly renders links-inline.txt 1`] = `
 `;
 
 exports[`#basic properly renders links-reference.txt 1`] = `
-"Foo \\\\href{1}{bar}.
+"Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
-Foo \\\\href{1}{bar}.
+Foo \\\\hyperref[1]{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{http://zestedesavoir.com/url/}}
 
-With \\\\href{b}{embedded [brackets]}.
+With \\\\hyperref[b]{embedded [brackets]}.
 
 
 
-Indented \\\\href{once}{once}.
+Indented \\\\hyperref[once]{once}.
 
 
 
-Indented \\\\href{twice}{twice}.
+Indented \\\\hyperref[twice]{twice}.
 
 
 
-Indented \\\\href{thrice}{thrice}.
+Indented \\\\hyperref[thrice]{thrice}.
 
 
 
@@ -684,11 +684,11 @@ Indented [four] times.
 
 \\\\footnote{\\\\label{b}\\\\externalLink{/url/}{http://zestedesavoir.com/url/}}
 
-With \\\\href{angle brackets}{angle brackets}.
+With \\\\hyperref[angle brackets]{angle brackets}.
 
 
 
-And \\\\href{without}{without}.
+And \\\\hyperref[without]{without}.
 
 
 
@@ -696,12 +696,12 @@ And \\\\href{without}{without}.
 
 \\\\footnote{\\\\label{without}\\\\externalLink{http://example.com/}{http://example.com/}}
 
-With \\\\href{line breaks}{line
+With \\\\hyperref[line breaks]{line
 breaks}
 
 
 
-and \\\\href{line breaks}{line
+and \\\\hyperref[line breaks]{line
 breaks} with one space.
 
 
@@ -713,18 +713,18 @@ breaks[] with two spaces.
 
 \\\\footnote{\\\\label{line breaks}\\\\externalLink{http://example.com}{http://example.com}}
 
-\\\\href{short ref}{short ref}
+\\\\hyperref[short ref]{short ref}
 
 
 
-\\\\href{short ref}{short
+\\\\hyperref[short ref]{short
 ref}
 
 
 
 \\\\footnote{\\\\label{short ref}\\\\externalLink{http://example.com}{http://example.com}}
 
-\\\\href{a ref}{a ref}
+\\\\hyperref[a ref]{a ref}
 
 
 
@@ -3333,11 +3333,11 @@ This \\\\& that.
 
 
 
-Here's a \\\\href{1}{link} with an ampersand in the URL.
+Here's a \\\\hyperref[1]{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
+Here's a link with an amersand in the link text: \\\\hyperref[2]{AT\\\\&T}.
 
 
 
@@ -3570,25 +3570,25 @@ The end."
 `;
 
 exports[`#pl #Tests_2007 properly renders Links, shortcut references.txt 1`] = `
-"This is the \\\\href{simple case}{simple case}.
+"This is the \\\\hyperref[simple case]{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{http://zestedesavoir.com/simple}}
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break}.
 
 
 
-This one has a \\\\href{line break}{line
+This one has a \\\\hyperref[line break]{line
 break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{http://zestedesavoir.com/foo}}
 
-\\\\href{that}{this} and the \\\\href{other}{other}
+\\\\hyperref[that]{this} and the \\\\hyperref[other]{other}
 
 
 

--- a/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/old-suite-latex.test.js.snap
@@ -21,11 +21,11 @@ This \\\\& that.
 
 
 
-Here's a link\\\\ref{1} with an ampersand in the URL.
+Here's a \\\\href{1}{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: AT\\\\&T\\\\ref{2}.
+Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
 
 
 
@@ -636,33 +636,33 @@ exports[`#basic properly renders links-inline.txt 1`] = `
 `;
 
 exports[`#basic properly renders links-reference.txt 1`] = `
-"Foo bar\\\\ref{1}.
+"Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
-Foo bar\\\\ref{1}.
+Foo \\\\href{1}{bar}.
 
 
 
 \\\\footnote{\\\\label{1}\\\\externalLink{/url/}{http://zestedesavoir.com/url/}}
 
-With embedded [brackets]\\\\ref{b}.
+With \\\\href{b}{embedded [brackets]}.
 
 
 
-Indented once\\\\ref{once}.
+Indented \\\\href{once}{once}.
 
 
 
-Indented twice\\\\ref{twice}.
+Indented \\\\href{twice}{twice}.
 
 
 
-Indented thrice\\\\ref{thrice}.
+Indented \\\\href{thrice}{thrice}.
 
 
 
@@ -684,11 +684,11 @@ Indented [four] times.
 
 \\\\footnote{\\\\label{b}\\\\externalLink{/url/}{http://zestedesavoir.com/url/}}
 
-With angle brackets\\\\ref{angle brackets}.
+With \\\\href{angle brackets}{angle brackets}.
 
 
 
-And without\\\\ref{without}.
+And \\\\href{without}{without}.
 
 
 
@@ -696,13 +696,13 @@ And without\\\\ref{without}.
 
 \\\\footnote{\\\\label{without}\\\\externalLink{http://example.com/}{http://example.com/}}
 
-With line
-breaks\\\\ref{line breaks}
+With \\\\href{line breaks}{line
+breaks}
 
 
 
-and line
-breaks\\\\ref{line breaks} with one space.
+and \\\\href{line breaks}{line
+breaks} with one space.
 
 
 
@@ -713,18 +713,18 @@ breaks[] with two spaces.
 
 \\\\footnote{\\\\label{line breaks}\\\\externalLink{http://example.com}{http://example.com}}
 
-short ref\\\\ref{short ref}
+\\\\href{short ref}{short ref}
 
 
 
-short
-ref\\\\ref{short ref}
+\\\\href{short ref}{short
+ref}
 
 
 
 \\\\footnote{\\\\label{short ref}\\\\externalLink{http://example.com}{http://example.com}}
 
-a ref\\\\ref{a ref}
+\\\\href{a ref}{a ref}
 
 
 
@@ -3333,11 +3333,11 @@ This \\\\& that.
 
 
 
-Here's a link\\\\ref{1} with an ampersand in the URL.
+Here's a \\\\href{1}{link} with an ampersand in the URL.
 
 
 
-Here's a link with an amersand in the link text: AT\\\\&T\\\\ref{2}.
+Here's a link with an amersand in the link text: \\\\href{2}{AT\\\\&T}.
 
 
 
@@ -3570,25 +3570,25 @@ The end."
 `;
 
 exports[`#pl #Tests_2007 properly renders Links, shortcut references.txt 1`] = `
-"This is the simple case\\\\ref{simple case}.
+"This is the \\\\href{simple case}{simple case}.
 
 
 
 \\\\footnote{\\\\label{simple case}\\\\externalLink{/simple}{http://zestedesavoir.com/simple}}
 
-This one has a line
-break\\\\ref{line break}.
+This one has a \\\\href{line break}{line
+break}.
 
 
 
-This one has a line
-break\\\\ref{line break} with a line-ending space.
+This one has a \\\\href{line break}{line
+break} with a line-ending space.
 
 
 
 \\\\footnote{\\\\label{line break}\\\\externalLink{/foo}{http://zestedesavoir.com/foo}}
 
-this\\\\ref{that} and the other\\\\ref{other}
+\\\\href{that}{this} and the \\\\href{other}{other}
 
 
 

--- a/packages/zmarkdown/__tests__/fixtures/latex/code-inside-notes.fixture.md
+++ b/packages/zmarkdown/__tests__/fixtures/latex/code-inside-notes.fixture.md
@@ -1,0 +1,14 @@
+hello [^note][^note-caption]
+
+[^note]:
+    test
+    ```javascript
+     console.log('hello')
+    ```
+
+[^note-caption]:
+    test
+    ```javascript
+    console.log('hello')
+    ```
+    Code: with a legend

--- a/packages/zmarkdown/__tests__/latex.tests.js
+++ b/packages/zmarkdown/__tests__/latex.tests.js
@@ -200,3 +200,10 @@ test('properly loads extensions - mhchem', () => {
 
   return expect(result).resolves.toContain(markdown)
 })
+
+test('codes in notes', () => {
+  const fixture = fixtures['code-inside-notes']
+  const p = renderString()(fixture.replace(/·/g, ' '))
+
+  return expect(p).resolves.toMatchSnapshot()
+})

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -1,9 +1,10 @@
 const remarkConfig = require('./remark')
 const escape = require('rebber/dist/escaper')
-
+const appendix = require('rebber-plugins/dist/preprocessors/codeVisitor')
 const rebberConfig = {
   preprocessors: {
-    tableCell: require('rebber-plugins/dist/preprocessors/codeVisitor'),
+    tableCell: appendix,
+    footnoteDefinition: [appendix],
   },
   overrides: {
     abbr: require('rebber-plugins/dist/type/abbr'),

--- a/packages/zmarkdown/config/rebber.js
+++ b/packages/zmarkdown/config/rebber.js
@@ -47,6 +47,7 @@ const rebberConfig = {
     }, {}),
   },
   codeAppendiceTitle: 'Annexes',
+  appendiceReferenceGenerator: (appendixIndex) => `Annexe de code ${appendixIndex}`,
   customBlocks: {
     map: {
       error: 'Error',


### PR DESCRIPTION
Hello,

I tried to fix the "code in footnotes" issue and found some annoying issues in the way we manage appendices.

- references were totally wrong
- no links were provided
- many heading "appendix"
- same appendix number if multi table

This is the state of my work, I still need to know:

- How can I say I am inside an appendix?
- Which command is good to link to reference?
- is there a better way to do what we do?