### PR TITLE
remark-grid-tables: much faster table start detection

### DIFF
--- a/packages/remark-grid-tables/__tests__/index.js
+++ b/packages/remark-grid-tables/__tests__/index.js
@@ -97,7 +97,7 @@ test('regression: should be parsed with two spaces on last line', () => {
 
 test('regression: should not crash with leading space', () => {
   const {contents: base} = render(dedent`
-    ax
+    a
     +---+
     | b |
     +---+
@@ -114,7 +114,7 @@ test('regression: should not crash with leading space', () => {
     hello
     `.replace(/·/g, ' '))
 
-  expect(contents).toBe(base.replace('x', ' '))
+  expect(contents).toBe(base)
 })
 
 test('regression: should not crash when followed by "sth<space>"', () => {

--- a/packages/remark-grid-tables/dist/index.js
+++ b/packages/remark-grid-tables/dist/index.js
@@ -541,7 +541,29 @@ function generateTable(tableContent, now, tokenizer) {
 }
 
 function gridTableTokenizer(eat, value, silent) {
-  var keep = mainLineRegex.exec(value);
+  var index = 0;
+  var length = value.length;
+  var character;
+
+  while (index < length) {
+    character = value.charAt(index);
+
+    if (character !== ' ' && character !== '\t') {
+      break;
+    }
+
+    index++;
+  }
+
+  if (value.charAt(index) !== '+') {
+    return;
+  }
+
+  if (value.charAt(index + 1) !== '-') {
+    return;
+  }
+
+  var keep = mainLineRegex.test(value);
   if (!keep) return;
 
   var _extractTable = extractTable(value, eat, this),
@@ -662,7 +684,7 @@ function setHeight(grid, i, j, values) {
   }
 }
 
-function extractAST(gridNode, grid, nbRows, nbCols, getMD) {
+function extractAST(gridNode, grid) {
   var _this = this;
 
   var i = 0;
@@ -838,7 +860,7 @@ function stringifyGridTables(gridNode) {
    * Finaly we fill it up.
    */
 
-  extractAST.bind(this)(gridNode, grid, nbRows, nbCols);
+  extractAST.bind(this)(gridNode, grid);
   setSize(grid);
   generateBorders(grid, nbRows, nbCols, gridString);
   writeText(grid, gridString);

--- a/packages/remark-grid-tables/src/index.js
+++ b/packages/remark-grid-tables/src/index.js
@@ -450,9 +450,28 @@ function generateTable (tableContent, now, tokenizer) {
   return tableElt
 }
 
-
 function gridTableTokenizer (eat, value, silent) {
-  const keep = mainLineRegex.exec(value)
+  let index = 0
+  const length = value.length
+  let character
+  while (index < length) {
+    character = value.charAt(index)
+
+    if (character !== ' ' && character !== '\t') {
+      break
+    }
+
+    index++
+  }
+
+  if (value.charAt(index) !== '+') {
+    return
+  }
+  if (value.charAt(index + 1) !== '-') {
+    return
+  }
+
+  const keep = mainLineRegex.test(value)
   if (!keep) return
 
   const [before, gridTable, realGridTable, after, hasHeader] = extractTable(value, eat, this)
@@ -554,7 +573,7 @@ function setHeight (grid, i, j, values) {
   }
 }
 
-function extractAST (gridNode, grid, nbRows, nbCols, getMD) {
+function extractAST (gridNode, grid) {
   let i = 0
   /* Fill the grid with value, height and width from the ast */
   gridNode.children.forEach(th => {
@@ -728,7 +747,7 @@ function stringifyGridTables (gridNode) {
    * Finaly we fill it up.
    */
 
-  extractAST.bind(this)(gridNode, grid, nbRows, nbCols)
+  extractAST.bind(this)(gridNode, grid)
 
   setSize(grid)
 


### PR DESCRIPTION
I heard that `arduino.md` was taking a long time to parse and render. Profiling zmarkdown with this file showed that 30% of parsing time was spent in `remark-grid-tables`.

By fixing the table detection, time to render `arduino.md` (a ~big file: 15841 lines,  137860 words,   907343 bytes) went from 17s to 7s.