### PR TITLE
[remark-emoticons] Solve using confusable locators

### DIFF
--- a/packages/remark-emoticons/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-emoticons/__tests__/__snapshots__/index.js.snap
@@ -56,3 +56,5 @@ Smiley after another node w/2 spaces: [link](#foo)  :)
 Smiley after another node w/3 spaces: [link](#foo)   :)
 "
 `;
+
+exports[`unicode emoticons 1`] = `"<p><img src=\\"/static/smileys/svg/1f9d0.svg\\" alt=\\"🧐\\" class=\\"foo bar\\"></p>"`;

--- a/packages/remark-emoticons/__tests__/index.js
+++ b/packages/remark-emoticons/__tests__/index.js
@@ -35,6 +35,7 @@ const config = {
     ':euh:': '/static/smileys/unsure.gif',
     ':waw:': '/static/smileys/waw.png',
     ':zorro:': '/static/smileys/zorro.png',
+    '🧐': '/static/smileys/svg/1f9d0.svg',
   },
   classes: 'foo bar',
 }
@@ -88,6 +89,21 @@ test('does not eat spaces leading to a smiley', () => {
   `)
   expect(contents).not.toContain('</em><img')
   expect(contents).not.toContain('</a><img')
+})
+
+test('confusable locators', () => {
+  const {contents} = render(dedent`
+    :)     o_O   :)
+  `)
+  expect((contents.match(/<img/g) || []).length).toBe(3)
+})
+
+test('unicode emoticons', () => {
+  const {contents} = render(dedent`
+    🧐
+  `)
+  expect(contents).toContain('<img')
+  expect(contents).toMatchSnapshot()
 })
 
 test('emoticons without class', () => {

--- a/packages/remark-emoticons/src/index.js
+++ b/packages/remark-emoticons/src/index.js
@@ -41,7 +41,7 @@ module.exports = function inlinePlugin (ctx) {
 
       if (match !== -1) {
         // A smiley should be precedeed by at least one whitespace
-        if (whitespace(value[match - 1]) && (lowestMatch === -1 || match > lowestMatch)) {
+        if (whitespace(value[match - 1]) && (lowestMatch === -1 || match < lowestMatch)) {
           lowestMatch = match
         }
       }


### PR DESCRIPTION
Solve a bug that made remark think there were no emoticons while it was indeed missing some of them.