### PR TITLE
Solve a bug on emoticons

### DIFF
--- a/packages/remark-emoticons/__tests__/index.js
+++ b/packages/remark-emoticons/__tests__/index.js
@@ -98,6 +98,14 @@ test('confusable locators', () => {
   expect((contents.match(/<img/g) || []).length).toBe(3)
 })
 
+test('multiple chars no match', () => {
+  const {contents} = render(dedent`
+    this contains an o_O
+  `)
+
+  expect((contents.match(/<img/g) || []).length).toBe(1)
+})
+
 test('unicode emoticons', () => {
   const {contents} = render(dedent`
     🧐


### PR DESCRIPTION
When the following conditions were met:

- an emoticon is on a line that also contains text;
- the text contains at least once the first character of the emoticon;
- all of the concerned characters are not preceeded by a space, but the emoticon is.

the emoticon would then not render at all. This was caused by the locator stopping it's search too early; a loop was added to prevent this from happening, and a test was added to match the behavior.