### PR TITLE
Allow inverted ranges in hl_lines

### DIFF
--- a/packages/rebber/dist/types/code.js
+++ b/packages/rebber/dist/types/code.js
@@ -1,5 +1,19 @@
 "use strict";
 
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
 /* Expose. */
 module.exports = code;
 var codeBlockParamsMapping = [null, 'hl_lines=', 'linenostart='];
@@ -32,24 +46,35 @@ var defaultMacro = function defaultMacro(content, lang, attrs) {
         if (_param === 'hl_lines=') {
           var hlItems = value.split(/,| /);
 
-          for (var _i in hlItems) {
-            var item = hlItems[_i];
+          var _iterator = _createForOfIteratorHelper(hlItems.entries()),
+              _step;
 
-            if (!item.includes('-')) {
-              continue;
+          try {
+            for (_iterator.s(); !(_step = _iterator.n()).done;) {
+              var _step$value = _slicedToArray(_step.value, 2),
+                  _i = _step$value[0],
+                  item = _step$value[1];
+
+              if (!item.includes('-')) {
+                continue;
+              }
+
+              var n = item.split('-').map(function (n) {
+                return parseInt(n);
+              }).filter(function (n) {
+                return !isNaN(n);
+              });
+
+              if (n.length !== 2) {
+                continue;
+              }
+
+              hlItems[_i] = "".concat(Math.min(n[0], n[1]), "-").concat(Math.max(n[0], n[1]));
             }
-
-            var n = item.split('-').map(function (n) {
-              return parseInt(n);
-            }).filter(function (n) {
-              return !isNaN(n);
-            });
-
-            if (n.length !== 2) {
-              continue;
-            }
-
-            hlItems[_i] = "".concat(Math.min(n[0], n[1]), "-").concat(Math.max(n[0], n[1]));
+          } catch (err) {
+            _iterator.e(err);
+          } finally {
+            _iterator.f();
           }
 
           value = hlItems.join(',');

--- a/packages/rebber/dist/types/code.js
+++ b/packages/rebber/dist/types/code.js
@@ -25,6 +25,34 @@ var defaultMacro = function defaultMacro(content, lang, attrs) {
 
         if (value.startsWith('"') && value.endsWith('"') || value.startsWith("'") && value.endsWith("'")) {
           value = value.slice(1, -1).trim();
+        } // For hl_lines, we parse the parameters to ensure we don't have
+        // inverted ranges.
+
+
+        if (_param === 'hl_lines=') {
+          var hlItems = value.split(/, /);
+
+          for (var _i in hlItems) {
+            var item = hlItems[_i];
+
+            if (!item.includes('-')) {
+              continue;
+            }
+
+            var n = item.split('-').map(function (n) {
+              return parseInt(n);
+            }).filter(function (n) {
+              return !isNaN(n);
+            });
+
+            if (n.length !== 2) {
+              continue;
+            }
+
+            hlItems[_i] = "".concat(Math.min(n[0], n[1]), "-").concat(Math.max(n[0], n[1]));
+          }
+
+          value = hlItems.join(',');
         }
 
         localCodeBlockParams[i] = value;

--- a/packages/rebber/dist/types/code.js
+++ b/packages/rebber/dist/types/code.js
@@ -30,7 +30,7 @@ var defaultMacro = function defaultMacro(content, lang, attrs) {
 
 
         if (_param === 'hl_lines=') {
-          var hlItems = value.split(/, /);
+          var hlItems = value.split(/,| /);
 
           for (var _i in hlItems) {
             var item = hlItems[_i];

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -37,6 +37,28 @@ const defaultMacro = (content, lang, attrs) => {
           value = value.slice(1, -1).trim()
         }
 
+        // For hl_lines, we parse the parameters to ensure we don't have
+        // inverted ranges.
+        if (param === 'hl_lines=') {
+          const hlItems = value.split(/, /)
+
+          for (const i in hlItems) {
+            const item = hlItems[i]
+            if (!item.includes('-')) {
+              continue
+            }
+
+            const n = item.split('-').map(n => parseInt(n)).filter(n => !isNaN(n))
+            if (n.length !== 2) {
+              continue
+            }
+
+            hlItems[i] = `${Math.min(n[0], n[1])}-${Math.max(n[0], n[1])}`
+          }
+
+          value = hlItems.join(',')
+        }
+
         localCodeBlockParams[i] = value
       }
     }

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -42,8 +42,7 @@ const defaultMacro = (content, lang, attrs) => {
         if (param === 'hl_lines=') {
           const hlItems = value.split(/,| /)
 
-          for (const i in hlItems) {
-            const item = hlItems[i]
+          for (const [i, item] of hlItems.entries()) {
             if (!item.includes('-')) {
               continue
             }

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -40,7 +40,7 @@ const defaultMacro = (content, lang, attrs) => {
         // For hl_lines, we parse the parameters to ensure we don't have
         // inverted ranges.
         if (param === 'hl_lines=') {
-          const hlItems = value.split(/, /)
+          const hlItems = value.split(/,| /)
 
           for (const i in hlItems) {
             const item = hlItems[i]

--- a/packages/zmarkdown/__tests__/__snapshots__/html-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/html-suite.test.js.snap
@@ -51,6 +51,15 @@ exports[`code highlight special cases supports hl_lines - interval syntax 1`] = 
 </code></pre></div>"
 `;
 
+exports[`code highlight special cases supports hl_lines - interval syntax reversed 1`] = `
+"<div class=\\"hljs-code-div hljs-code-python\\"><div class=\\"hljs-line-numbers\\"><span data-count=\\"1\\" class=\\"hll\\"></span><span data-count=\\"2\\" class=\\"hll\\"></span><span data-count=\\"3\\" class=\\"hll\\"></span><span data-count=\\"4\\"></span><span data-count=\\"5\\"></span></div><pre><code class=\\"hljs language-python\\"><span class=\\"hljs-function\\"><span class=\\"hljs-keyword\\">def</span> <span class=\\"hljs-title\\">main</span>():</span>
+  print(<span class=\\"hljs-string\\">'It\\\\'s amazing!'</span>)
+
+<span class=\\"hljs-function\\"><span class=\\"hljs-keyword\\">def</span> <span class=\\"hljs-title\\">unused</span>():</span>
+  print(<span class=\\"hljs-string\\">'Please use me!'</span>)
+</code></pre></div>"
+`;
+
 exports[`code highlight special cases supports hl_lines - spaced syntax 1`] = `
 "<div class=\\"hljs-code-div hljs-code-python\\"><div class=\\"hljs-line-numbers\\"><span data-count=\\"1\\"></span><span data-count=\\"2\\"></span><span data-count=\\"3\\"></span><span data-count=\\"4\\" class=\\"hll\\"></span><span data-count=\\"5\\" class=\\"hll\\"></span></div><pre><code class=\\"hljs language-python\\"><span class=\\"hljs-function\\"><span class=\\"hljs-keyword\\">def</span> <span class=\\"hljs-title\\">main</span>():</span>
   print(<span class=\\"hljs-string\\">'It\\\\'s amazing!'</span>)

--- a/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
@@ -51,6 +51,14 @@ print('bla')
 
 
 
+\\\\begin{CodeBlock}[][2-3]{python}
+print('bla')
+print('bla')
+print('bla')
+\\\\end{CodeBlock}
+
+
+
 \\\\begin{CodeBlock}{text}
 a code without lang
 \\\\end{CodeBlock}"

--- a/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
@@ -51,7 +51,13 @@ print('bla')
 
 
 
-\\\\begin{CodeBlock}[][2-3]{python}
+\\\\begin{CodeBlock}{text}
+a code without lang
+\\\\end{CodeBlock}"
+`;
+
+exports[`code+reversed-hl 1`] = `
+"\\\\begin{CodeBlock}[][2-3]{python}
 print('bla')
 print('bla')
 print('bla')
@@ -59,8 +65,11 @@ print('bla')
 
 
 
-\\\\begin{CodeBlock}{text}
-a code without lang
+\\\\begin{CodeBlock}[][1-2,3-4]{python}
+print('bla')
+print('bla')
+print('bla')
+print('bla')
 \\\\end{CodeBlock}"
 `;
 

--- a/packages/zmarkdown/__tests__/html-suite.test.js
+++ b/packages/zmarkdown/__tests__/html-suite.test.js
@@ -299,7 +299,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines="4 5"
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
         print('Please use me!')
       \`\`\`
@@ -315,7 +315,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=4,5
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
         print('Please use me!')
       \`\`\`
@@ -331,10 +331,10 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=1-3
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
-        print('Please use me!')
-      \`\`\`
+      print('Please use me!')
+    \`\`\`
     `
 
     const result = await renderString(input)
@@ -344,10 +344,10 @@ describe('code highlight special cases', () => {
 
   it('supports hl_lines - interval syntax reversed', async () => {
     const input = dedent `
-      \`\`\`python hl_lines=3-1
-      def main():
-        print('It\'s amazing!')
-
+    \`\`\`python hl_lines=3-1
+    def main():
+      print('It\'s amazing!')
+      
       def unused():
         print('Please use me!')
       \`\`\`
@@ -363,7 +363,7 @@ describe('code highlight special cases', () => {
       \`\`\`python linenostart=3
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
         print('Please use me!')
       \`\`\`
@@ -379,7 +379,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=4 linenostart=3
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
         print('Please use me!')
       \`\`\`
@@ -393,7 +393,7 @@ describe('code highlight special cases', () => {
       \`\`\`python none hl_lines
       def main():
         print('It\'s amazing!')
-
+      
       def unused():
         print('Please use me!')
       \`\`\`

--- a/packages/zmarkdown/__tests__/html-suite.test.js
+++ b/packages/zmarkdown/__tests__/html-suite.test.js
@@ -299,7 +299,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines="4 5"
       def main():
         print('It\'s amazing!')
-      
+
       def unused():
         print('Please use me!')
       \`\`\`
@@ -315,7 +315,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=4,5
       def main():
         print('It\'s amazing!')
-      
+
       def unused():
         print('Please use me!')
       \`\`\`
@@ -331,7 +331,23 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=1-3
       def main():
         print('It\'s amazing!')
-      
+
+      def unused():
+        print('Please use me!')
+      \`\`\`
+    `
+
+    const result = await renderString(input)
+    expect((result.match(/class="hll"/g) || []).length).toBe(3)
+    expect(result).toMatchSnapshot()
+  })
+
+  it('supports hl_lines - interval syntax reversed', async () => {
+    const input = dedent `
+      \`\`\`python hl_lines=3-1
+      def main():
+        print('It\'s amazing!')
+
       def unused():
         print('Please use me!')
       \`\`\`
@@ -347,7 +363,7 @@ describe('code highlight special cases', () => {
       \`\`\`python linenostart=3
       def main():
         print('It\'s amazing!')
-      
+
       def unused():
         print('Please use me!')
       \`\`\`
@@ -363,7 +379,7 @@ describe('code highlight special cases', () => {
       \`\`\`python hl_lines=4 linenostart=3
       def main():
         print('It\'s amazing!')
-      
+
       def unused():
         print('Please use me!')
       \`\`\`
@@ -377,7 +393,7 @@ describe('code highlight special cases', () => {
       \`\`\`python none hl_lines
       def main():
         print('It\'s amazing!')
-      
+
       def unused():
         print('Please use me!')
       \`\`\`

--- a/packages/zmarkdown/__tests__/html-suite.test.js
+++ b/packages/zmarkdown/__tests__/html-suite.test.js
@@ -328,11 +328,11 @@ describe('code highlight special cases', () => {
 
   it('supports hl_lines - interval syntax', async () => {
     const input = dedent `
-      \`\`\`python hl_lines=1-3
-      def main():
-        print('It\'s amazing!')
-      
-      def unused():
+    \`\`\`python hl_lines=1-3
+    def main():
+      print('It\'s amazing!')
+    
+    def unused():
       print('Please use me!')
     \`\`\`
     `
@@ -347,10 +347,10 @@ describe('code highlight special cases', () => {
     \`\`\`python hl_lines=3-1
     def main():
       print('It\'s amazing!')
-      
-      def unused():
-        print('Please use me!')
-      \`\`\`
+    
+    def unused():
+      print('Please use me!')
+    \`\`\`
     `
 
     const result = await renderString(input)

--- a/packages/zmarkdown/__tests__/latex-suite.test.js
+++ b/packages/zmarkdown/__tests__/latex-suite.test.js
@@ -234,7 +234,7 @@ test('code+caption', () => {
 
 test('list', () => {
   const p = renderString(dedent`
-    - an
+    - an 
     - **unordered**
     - list
 
@@ -265,68 +265,68 @@ test('mix-1', () => {
   const p = renderString(dedent`
     (for convenience, · are replaced with simple single spaces in the tests)
     # first 1
-
+    
     foo··
     bar
-
+    
     Disrupt ~~asymmetrical~~ unicorn, pok pok kale chips umami selfies gastropub food truck flannel. Blue **bottle craft** beer hexagon artisan. Chia gochujang crucifix, ^ready^ ^made^ hammock _blog succulents_ sriracha raw denim scenester cray typewriter fashion axe ~art~ *party*. Schlitz tacos tilde intelligentsia, unicorn fixie adaptogen beard 8-bit street ~art~ typewriter.
-
+    
     ## *second* 1
-
+    
     **Literally selfies tbh lo-fi. Actually health goth ennui, brooklyn retro polaroid sriracha. Kogi live-edge mixtape marfa street ~art~ synth. Godard synth truffaut selfies, vape fanny ~~pack~~ subway tile. Stumptown af pabst, try-hard fam ethical actually four dollar toast. Microdosing kogi brooklyn, locavore jianbing etsy sartorial _YOLO_. Williamsburg salvia photo booth ^readymade^ listicle man braid.**
-
+    
     ---
-
+    
     > Marfa pickled helvetica put a bird on it hot chicken williamsburg.
     > Edison bulb asymmetrical \`keffiyeh\` schlitz iceland put a bird on it hoodie affogato.
     >
     > Tofu tote bag distillery viral knausgaard, health goth asymmetrical.
     Source: Guru
-
+    
     Asymmetrical pug scenester sustainable enamel pin distillery quinoa keffiyeh. Flannel humblebrag PBR&B polaroid banh mi wolf. Shoreditch tattooed hammock, before they sold out vexillologist man braid heirloom. Activated charcoal craft beer cloud bread meh biodiesel pabst.
-
+    
     ### ~~third~~ 1
-
+    
     Art party keytar godard iceland neutra cronut. Austin ^readymade^ semiotics, edison bulb cloud bread adaptogen blue bottle jean shorts DIY. Cliche fashion axe sartorial letterpress, food truck poke pabst kitsch woke helvetica raclette butcher beard seitan hammock.
-
+    
     \`foo
     bar\`
-
+    
     > \`fo\o
     > bar\`
-
+    
     Hexagon lo-fi seitan you probably haven't heard of them, bicycle rights small batch meditation try-hard green juice banh mi keffiyeh. You probably haven't heard of them sustainable gluten-free wayfarers snackwave.
-
+    
     ### third 2
     #### ~~fo~~u**r**t*h* _1_
-
+    
     Mumblecore kombucha offal, health goth next level before they sold out gluten-free chicharrones keffiyeh. Mumblecore kickstarter hoodie fixie keffiyeh. Microdosing lo-fi taiyaki irony pok pok. Banjo brooklyn umami succulents flexitarian. Swag sartorial scenester synth viral.
-
+    
     ##### fifth 1
-
+    
     Banjo bespoke subway tile, street ~a*r*~^t^ drinking vinegar offal franzen. Pour-over green juice vaporware kale chips. Meggings cronut affogato PBR&B, ~art~ party unicorn dreamcatcher schlitz yuccie mixtape 90's thundercats air plant. Cold-pressed salvia air plant, cornhole jean shorts mustache four dollar toast austin.
-
+    
     ### third 3
-
+    
     Meditation heirloom chicharrones, sartorial man braid hot chicken sustainable. Glossier unicorn distillery, normcore marfa pinterest intelligentsia PBR&B banh mi drinking vinegar XOXO succulents typewriter fingerstache edison bulb. Meditation ethical cronut glossier cliche kickstarter.
-
+    
     #### fourth 2
-
+    
     Venmo bushwick food truck chartreuse fam. Everyday carry gastropub glossier, cold-pressed salvia migas keytar. Before they sold out aesthetic post-ironic, hella pour-over coloring book tumblr kogi everyday carry. Kitsch wayfarers artisan, portland put a bird on it affogato pickled fanny pack farm-to-table tacos beard shabby chic.
-
+    
     #### fourth 3
-
+    
     Chambray intelligentsia vape listicle. Pok pok snackwave cronut retro hot chicken, trust fund master cleanse keytar forage dreamcatcher. Taiyaki actually deep v, godard small batch irony lumbersexual unicorn cardigan af. Irony lumbersexual salvia, pitchfork fam snackwave man bun. Kitsch jianbing intelligentsia freegan, waistcoat raw denim cloud bread vice cray etsy listicle skateboard jean shorts.
-
+    
     ##### fifth 2
-
+    
     Asymmetrical normcore portland, vaporware viral tote bag DIY slow-carb kogi fanny pack. Keffiyeh ennui church-key, irony VHS man bun edison bulb listicle cloud bread try-hard cred lumbersexual lo-fi glossier.
-
+    
     # first 2
     ## second 2
     ##### fifth 3
-
-    Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh.
+    
+    Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh.  
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -336,20 +336,20 @@ test('mix-2', () => {
   const p = renderString(dedent`
     (for convenience, · are replaced with simple single spaces in the tests)
     # first 1
-
+    
     > Code inside quote
     > \`\`\`python
     > print('bla')
     > \`\`\`
     > Code: code source
     Source: Quotation Source
-
+    
     \`\`\`python
     print('bla')
     \`\`\`
     Code: First ||CTRL||+||S||
     Code: Second
-
+    
     \`\`\`python
     print('code without caption')
     \`\`\`
@@ -366,18 +366,18 @@ test('mix-3', () => {
     - item
     - item
     ->
-
+    
     # centered list
-
+    
     ->
     - item
     - item
     - item
     <-
-
-
+    
+    
     # left list
-
+    
     <-
     - item
     - item
@@ -404,17 +404,17 @@ test('mix-4', () => {
     | too   |                 |
     +-------+-----------------+
     Table: The new table ABBR [^foot] with ||CTRL|| + ||S||
-
+    
     *[ABBR]: abbreviation
-
+    
     [^foot]: a foot
-
+    
     +-----------+---------------------------------------------------------------+
     | title     |  image                                                        |
     +===========+===============================================================+
     | space     | ![space](https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg)|
     +-----------+---------------------------------------------------------------+
-
+    
     +-----------+--------------------+
     | title     | code               |
     +===========+====================+
@@ -424,7 +424,7 @@ test('mix-4', () => {
     | block     | \`\`\`python          |
     |           | print('bla')       |
     |           | \`\`\`                |
-    +-----------+--------------------+
+    +-----------+--------------------+  
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -434,8 +434,8 @@ test('mix-5', () => {
   const p = renderString(dedent`
     ![](http://www.numerama.com/content/uploads/2016/07/espace.jpg)
     Figure: espace[^node]
-
-    [^node]: Two things are infinite: the universe and human stupidity.
+    
+    [^node]: Two things are infinite: the universe and human stupidity.  
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -445,9 +445,9 @@ test('mix-6', () => {
   const p = renderString(dedent`
     !(https://www.youtube.com/watch?v=8TQIvdFl4aU)
     Video: a caption
-
+    
     !(https://www.youtube.com/watch?v=8TQIvdFl4aU)
-
+    
     no caption
   `.replace(/·/g, ' '))
 
@@ -543,9 +543,9 @@ test('custom-blocks', () => {
     | do not over-flattenize
     | [[s]]
     | | expected to be flattened
-    |
+    | 
     | first level
-    |
+    | 
     | [[q]]
     | | this remains a question
 
@@ -594,7 +594,7 @@ test('codes in notes', () => {
         \`\`\`javascript
         console.log('hello')
         \`\`\`
-
+    
     [^note-caption]:
         test
         \`\`\`javascript

--- a/packages/zmarkdown/__tests__/latex-suite.test.js
+++ b/packages/zmarkdown/__tests__/latex-suite.test.js
@@ -184,12 +184,18 @@ test('code', () => {
     print('bla')
     \`\`\`
 
+    \`\`\`python hl_lines=3-2
+    print('bla')
+    print('bla')
+    print('bla')
+    \`\`\`
+
     \`\`\`
     a code without lang
     \`\`\`
   `)
 
-  return expect(p).resolves.toMatchSnapshot()
+  return expect(p).resolves.toMatchSnapshot() && expect(p).not.toContain('3-2')
 })
 
 test('code+caption', () => {
@@ -212,7 +218,7 @@ test('code+caption', () => {
 
 test('list', () => {
   const p = renderString(dedent`
-    - an 
+    - an
     - **unordered**
     - list
 
@@ -243,68 +249,68 @@ test('mix-1', () => {
   const p = renderString(dedent`
     (for convenience, · are replaced with simple single spaces in the tests)
     # first 1
-    
+
     foo··
     bar
-    
+
     Disrupt ~~asymmetrical~~ unicorn, pok pok kale chips umami selfies gastropub food truck flannel. Blue **bottle craft** beer hexagon artisan. Chia gochujang crucifix, ^ready^ ^made^ hammock _blog succulents_ sriracha raw denim scenester cray typewriter fashion axe ~art~ *party*. Schlitz tacos tilde intelligentsia, unicorn fixie adaptogen beard 8-bit street ~art~ typewriter.
-    
+
     ## *second* 1
-    
+
     **Literally selfies tbh lo-fi. Actually health goth ennui, brooklyn retro polaroid sriracha. Kogi live-edge mixtape marfa street ~art~ synth. Godard synth truffaut selfies, vape fanny ~~pack~~ subway tile. Stumptown af pabst, try-hard fam ethical actually four dollar toast. Microdosing kogi brooklyn, locavore jianbing etsy sartorial _YOLO_. Williamsburg salvia photo booth ^readymade^ listicle man braid.**
-    
+
     ---
-    
+
     > Marfa pickled helvetica put a bird on it hot chicken williamsburg.
     > Edison bulb asymmetrical \`keffiyeh\` schlitz iceland put a bird on it hoodie affogato.
     >
     > Tofu tote bag distillery viral knausgaard, health goth asymmetrical.
     Source: Guru
-    
+
     Asymmetrical pug scenester sustainable enamel pin distillery quinoa keffiyeh. Flannel humblebrag PBR&B polaroid banh mi wolf. Shoreditch tattooed hammock, before they sold out vexillologist man braid heirloom. Activated charcoal craft beer cloud bread meh biodiesel pabst.
-    
+
     ### ~~third~~ 1
-    
+
     Art party keytar godard iceland neutra cronut. Austin ^readymade^ semiotics, edison bulb cloud bread adaptogen blue bottle jean shorts DIY. Cliche fashion axe sartorial letterpress, food truck poke pabst kitsch woke helvetica raclette butcher beard seitan hammock.
-    
+
     \`foo
     bar\`
-    
+
     > \`fo\o
     > bar\`
-    
+
     Hexagon lo-fi seitan you probably haven't heard of them, bicycle rights small batch meditation try-hard green juice banh mi keffiyeh. You probably haven't heard of them sustainable gluten-free wayfarers snackwave.
-    
+
     ### third 2
     #### ~~fo~~u**r**t*h* _1_
-    
+
     Mumblecore kombucha offal, health goth next level before they sold out gluten-free chicharrones keffiyeh. Mumblecore kickstarter hoodie fixie keffiyeh. Microdosing lo-fi taiyaki irony pok pok. Banjo brooklyn umami succulents flexitarian. Swag sartorial scenester synth viral.
-    
+
     ##### fifth 1
-    
+
     Banjo bespoke subway tile, street ~a*r*~^t^ drinking vinegar offal franzen. Pour-over green juice vaporware kale chips. Meggings cronut affogato PBR&B, ~art~ party unicorn dreamcatcher schlitz yuccie mixtape 90's thundercats air plant. Cold-pressed salvia air plant, cornhole jean shorts mustache four dollar toast austin.
-    
+
     ### third 3
-    
+
     Meditation heirloom chicharrones, sartorial man braid hot chicken sustainable. Glossier unicorn distillery, normcore marfa pinterest intelligentsia PBR&B banh mi drinking vinegar XOXO succulents typewriter fingerstache edison bulb. Meditation ethical cronut glossier cliche kickstarter.
-    
+
     #### fourth 2
-    
+
     Venmo bushwick food truck chartreuse fam. Everyday carry gastropub glossier, cold-pressed salvia migas keytar. Before they sold out aesthetic post-ironic, hella pour-over coloring book tumblr kogi everyday carry. Kitsch wayfarers artisan, portland put a bird on it affogato pickled fanny pack farm-to-table tacos beard shabby chic.
-    
+
     #### fourth 3
-    
+
     Chambray intelligentsia vape listicle. Pok pok snackwave cronut retro hot chicken, trust fund master cleanse keytar forage dreamcatcher. Taiyaki actually deep v, godard small batch irony lumbersexual unicorn cardigan af. Irony lumbersexual salvia, pitchfork fam snackwave man bun. Kitsch jianbing intelligentsia freegan, waistcoat raw denim cloud bread vice cray etsy listicle skateboard jean shorts.
-    
+
     ##### fifth 2
-    
+
     Asymmetrical normcore portland, vaporware viral tote bag DIY slow-carb kogi fanny pack. Keffiyeh ennui church-key, irony VHS man bun edison bulb listicle cloud bread try-hard cred lumbersexual lo-fi glossier.
-    
+
     # first 2
     ## second 2
     ##### fifth 3
-    
-    Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh.  
+
+    Messenger bag locavore swag raclette brunch whatever, portland food truck. PBR&B cred mlkshk, poke letterpress waistcoat celiac. La croix letterpress forage keffiyeh.
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -314,20 +320,20 @@ test('mix-2', () => {
   const p = renderString(dedent`
     (for convenience, · are replaced with simple single spaces in the tests)
     # first 1
-    
+
     > Code inside quote
     > \`\`\`python
     > print('bla')
     > \`\`\`
     > Code: code source
     Source: Quotation Source
-    
+
     \`\`\`python
     print('bla')
     \`\`\`
     Code: First ||CTRL||+||S||
     Code: Second
-    
+
     \`\`\`python
     print('code without caption')
     \`\`\`
@@ -344,18 +350,18 @@ test('mix-3', () => {
     - item
     - item
     ->
-    
+
     # centered list
-    
+
     ->
     - item
     - item
     - item
     <-
-    
-    
+
+
     # left list
-    
+
     <-
     - item
     - item
@@ -382,17 +388,17 @@ test('mix-4', () => {
     | too   |                 |
     +-------+-----------------+
     Table: The new table ABBR [^foot] with ||CTRL|| + ||S||
-    
+
     *[ABBR]: abbreviation
-    
+
     [^foot]: a foot
-    
+
     +-----------+---------------------------------------------------------------+
     | title     |  image                                                        |
     +===========+===============================================================+
     | space     | ![space](https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg)|
     +-----------+---------------------------------------------------------------+
-    
+
     +-----------+--------------------+
     | title     | code               |
     +===========+====================+
@@ -402,7 +408,7 @@ test('mix-4', () => {
     | block     | \`\`\`python          |
     |           | print('bla')       |
     |           | \`\`\`                |
-    +-----------+--------------------+  
+    +-----------+--------------------+
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -412,8 +418,8 @@ test('mix-5', () => {
   const p = renderString(dedent`
     ![](http://www.numerama.com/content/uploads/2016/07/espace.jpg)
     Figure: espace[^node]
-    
-    [^node]: Two things are infinite: the universe and human stupidity.  
+
+    [^node]: Two things are infinite: the universe and human stupidity.
   `.replace(/·/g, ' '))
 
   return expect(p).resolves.toMatchSnapshot()
@@ -423,9 +429,9 @@ test('mix-6', () => {
   const p = renderString(dedent`
     !(https://www.youtube.com/watch?v=8TQIvdFl4aU)
     Video: a caption
-    
+
     !(https://www.youtube.com/watch?v=8TQIvdFl4aU)
-    
+
     no caption
   `.replace(/·/g, ' '))
 
@@ -521,9 +527,9 @@ test('custom-blocks', () => {
     | do not over-flattenize
     | [[s]]
     | | expected to be flattened
-    | 
+    |
     | first level
-    | 
+    |
     | [[q]]
     | | this remains a question
 
@@ -572,7 +578,7 @@ test('codes in notes', () => {
         \`\`\`javascript
         console.log('hello')
         \`\`\`
-    
+
     [^note-caption]:
         test
         \`\`\`javascript

--- a/packages/zmarkdown/__tests__/latex-suite.test.js
+++ b/packages/zmarkdown/__tests__/latex-suite.test.js
@@ -184,18 +184,34 @@ test('code', () => {
     print('bla')
     \`\`\`
 
+    \`\`\`
+    a code without lang
+    \`\`\`
+  `)
+
+  return expect(p).resolves.toMatchSnapshot()
+})
+
+test('code+reversed-hl', () => {
+  const p = renderString(dedent`
     \`\`\`python hl_lines=3-2
     print('bla')
     print('bla')
     print('bla')
     \`\`\`
 
-    \`\`\`
-    a code without lang
+    \`\`\`python hl_lines=2-1,4-3
+    print('bla')
+    print('bla')
+    print('bla')
+    print('bla')
     \`\`\`
   `)
 
-  return expect(p).resolves.toMatchSnapshot() && expect(p).not.toContain('3-2')
+  return expect(p).resolves.toMatchSnapshot() &&
+    expect(p).not.toContain('3-2') &&
+    expect(p).not.toContain('2-1') &&
+    expect(p).not.toContain('4-3')
 })
 
 test('code+caption', () => {

--- a/packages/zmarkdown/utils/code-handler.js
+++ b/packages/zmarkdown/utils/code-handler.js
@@ -64,10 +64,15 @@ const rangeHandler = range => {
   function insert () {
     if (previousNumber >= 0) {
       const currentInt = parseInt(currentNumber)
-      const rangeLength = (currentInt - previousNumber) + 1
+      const previousInt = parseInt(previousNumber)
+
+      const minLineNumber = Math.min(currentInt, previousInt)
+      const maxLineNumber = Math.max(currentInt, previousInt)
+
+      const rangeLength = (maxLineNumber - minLineNumber) + 1
 
       parsedRange.push(...[...Array(rangeLength).keys()]
-        .map(i => i + previousNumber))
+        .map(i => i + minLineNumber))
     } else {
       parsedRange.push(parseInt(currentNumber))
     }


### PR DESCRIPTION
The parser won't crash if the range is entered inverted by the user, i.e. `hl_lines=2-1` instead of `hl_lines=1-2`. In this example, lines 1 and 2 will be highlighted.

Fixes #414.

#### Notes

- This fixes the problem in the HTML export but not in the LaTeX one where the range stays inverted. Don't know if it's a problem.
- I'm still very new to zmarkdown, so I don't know if I should add a test somewhere for that. I guess so?