### PR TITLE
Default to `text` for code highlighting

### DIFF
--- a/packages/zmarkdown/utils/code-handler.js
+++ b/packages/zmarkdown/utils/code-handler.js
@@ -104,7 +104,7 @@ const rangeHandler = range => {
 
 function code (_, node) {
   const value = node.value ? `${node.value}\n` : ''
-  const lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
+  const lang = (node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)) || 'text'
   const attrs = attrsParser(node.meta || '').prop
 
   const linenostart = parseInt(attrs.linenostart) || 1


### PR DESCRIPTION
The title is pretty self-explanatory: currently, when highlighting a code block without specifying a language, `lowlight` tries to guess a best match using regexes, but this procedure was recently found slow and sometimes unstable, so I suggest to remove it.