### PR TITLE
Fix LaTeX hlLine syntax

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -127,46 +127,6 @@ print('bla')
 
 
 
-\\\\begin{CodeBlock}[][1,2]{python}
-print('bla')
-print('bla')
-print('bla')
-\\\\end{CodeBlock}
-
-
-
-\\\\begin{CodeBlock}[][][10]{python}
-print('bla')
-print('bla')
-print('bla')
-\\\\end{CodeBlock}
-
-
-
-\\\\begin{CodeBlock}[][1,2][10]{python}
-print('bla')
-print('bla')
-print('bla')
-\\\\end{CodeBlock}
-
-
-
-\\\\begin{CodeBlock}[][2]{css}
-.tmp {
-  font-weight: bold;
-}
-\\\\end{CodeBlock}
-
-
-
-\\\\begin{CodeBlock}[][1,3]{css}
-.tmp {
-  font-weight: bold;
-}
-\\\\end{CodeBlock}
-
-
-
 \\\\begin{CodeBlock}{text}
 a code without lang
 \\\\end{CodeBlock}"
@@ -174,15 +134,6 @@ a code without lang
 
 exports[`code+caption 1`] = `
 "\\\\begin{CodeBlock}{python}
-print('bla')
-\\\\end{CodeBlock}
-\\\\captionof{listing}{With Source}
-
-
-
-\\\\begin{CodeBlock}[][1,2]{python}
-print('bla')
-print('bla')
 print('bla')
 \\\\end{CodeBlock}
 \\\\captionof{listing}{With Source}"

--- a/packages/rebber-plugins/__tests__/fixtures/code.fixture.md
+++ b/packages/rebber-plugins/__tests__/fixtures/code.fixture.md
@@ -2,36 +2,6 @@
 print('bla')
 ```
 
-```python hl_lines=1,2
-print('bla')
-print('bla')
-print('bla')
-```
-
-```python linenostart=10
-print('bla')
-print('bla')
-print('bla')
-```
-
-```python hl_lines=1,2 linenostart=10
-print('bla')
-print('bla')
-print('bla')
-```
-
-```css hl_lines="2"
-.tmp {
-  font-weight: bold;
-}
-```
-
-```css hl_lines='1,3'
-.tmp {
-  font-weight: bold;
-}
-```
-
 ```
 a code without lang
 ```

--- a/packages/rebber-plugins/__tests__/fixtures/figure-code.fixture.md
+++ b/packages/rebber-plugins/__tests__/fixtures/figure-code.fixture.md
@@ -2,10 +2,3 @@
 print('bla')
 ```
 Code: With Source
-
-```python hl_lines=1,2
-print('bla')
-print('bla')
-print('bla')
-```
-Code: With Source

--- a/packages/rebber-plugins/__tests__/rebber.test.js
+++ b/packages/rebber-plugins/__tests__/rebber.test.js
@@ -74,7 +74,7 @@ const integrationConfig = {
     image: (node) => `\\image{${node.url}}`,
   },
   figure: {
-    image: (_, caption, extra) => `\\image{${extra.url}}${caption ? `[${caption}]` : ''}\n`,
+    image: (_1, _2, caption, extra) => `\\image{${extra.url}}${caption ? `[${caption}]` : ''}\n`,
   },
 }
 

--- a/packages/rebber-plugins/dist/type/figure.js
+++ b/packages/rebber-plugins/dist/type/figure.js
@@ -5,7 +5,7 @@ var all = require('rebber/dist/all');
 
 var one = require('rebber/dist/one');
 
-var codeStringifier = require('rebber/dist/types/code').macro;
+var defaultCodeStringifier = require('rebber/dist/types/code').macro;
 
 var has = require('has');
 /* Expose. */
@@ -13,16 +13,17 @@ var has = require('has');
 
 module.exports = figure;
 var defaultMacros = {
-  blockquote: function blockquote(innerText) {
-    var caption = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'Anonymous';
+  blockquote: function blockquote(_, innerText) {
+    var caption = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'Anonymous';
     return "\\begin{Quotation}[".concat(caption, "]\n").concat(innerText, "\n\\end{Quotation}\n\n");
   },
-  code: function code(_code, caption, extra) {
-    // Remove the two last line feed
+  code: function code(ctx, _code, caption, extra) {
+    var codeStringifier = has(ctx, 'code') && ctx.code || defaultCodeStringifier; // Remove the two last line feed
+
     var rebberCode = codeStringifier(_code, extra.language, extra.others).slice(0, -2);
     return "".concat(rebberCode, "\n\\captionof{listing}{").concat(caption, "}\n\n");
   },
-  image: function image(_, caption, extra) {
+  image: function image(_1, _2, caption, extra) {
     return "\\begin{center}\n" + "\\includegraphics".concat(extra.width ? "[".concat(extra.width, "]") : '', "{").concat(extra.url, "}\n") + "\\captionof{figure}{".concat(caption, "}\n") + "\\end{center}\n";
   }
 };
@@ -75,5 +76,5 @@ function figure(ctx, node, index, parent) {
 
   var extra = has(makeExtra, type) ? makeExtra[type](wrappedNode) : undefined;
   var innerText = all(ctx, node) || node.value || '';
-  return macro(innerText.trim(), caption, extra);
+  return macro(ctx, innerText.trim(), caption, extra);
 }

--- a/packages/rebber-plugins/src/type/figure.js
+++ b/packages/rebber-plugins/src/type/figure.js
@@ -1,21 +1,23 @@
 /* Dependencies. */
 const all = require('rebber/dist/all')
 const one = require('rebber/dist/one')
-const codeStringifier = require('rebber/dist/types/code').macro
+const defaultCodeStringifier = require('rebber/dist/types/code').macro
 const has = require('has')
 
 /* Expose. */
 module.exports = figure
 
 const defaultMacros = {
-  blockquote: (innerText, caption = 'Anonymous') =>
+  blockquote: (_, innerText, caption = 'Anonymous') =>
     `\\begin{Quotation}[${caption}]\n${innerText}\n\\end{Quotation}\n\n`,
-  code: (code, caption, extra) => {
+  code: (ctx, code, caption, extra) => {
+    const codeStringifier = (has(ctx, 'code') && ctx.code) || defaultCodeStringifier
+
     // Remove the two last line feed
     const rebberCode = codeStringifier(code, extra.language, extra.others).slice(0, -2)
     return `${rebberCode}\n\\captionof{listing}{${caption}}\n\n`
   },
-  image: (_, caption, extra) =>
+  image: (_1, _2, caption, extra) =>
     `\\begin{center}\n` +
     `\\includegraphics${extra.width ? `[${extra.width}]` : ''}{${extra.url}}\n` +
     `\\captionof{figure}{${caption}}\n` +
@@ -64,5 +66,5 @@ function figure (ctx, node, index, parent) {
   const extra = has(makeExtra, type) ? makeExtra[type](wrappedNode) : undefined
   const innerText = all(ctx, node) || node.value || ''
 
-  return macro(innerText.trim(), caption, extra)
+  return macro(ctx, innerText.trim(), caption, extra)
 }

--- a/packages/rebber/dist/types/code.js
+++ b/packages/rebber/dist/types/code.js
@@ -1,104 +1,19 @@
 "use strict";
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
-function _createForOfIteratorHelper(o, allowArrayLike) { var it; if (typeof Symbol === "undefined" || o[Symbol.iterator] == null) { if (Array.isArray(o) || (it = _unsupportedIterableToArray(o)) || allowArrayLike && o && typeof o.length === "number") { if (it) o = it; var i = 0; var F = function F() {}; return { s: F, n: function n() { if (i >= o.length) return { done: true }; return { done: false, value: o[i++] }; }, e: function e(_e2) { throw _e2; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var normalCompletion = true, didErr = false, err; return { s: function s() { it = o[Symbol.iterator](); }, n: function n() { var step = it.next(); normalCompletion = step.done; return step; }, e: function e(_e3) { didErr = true; err = _e3; }, f: function f() { try { if (!normalCompletion && it["return"] != null) it["return"](); } finally { if (didErr) throw err; } } }; }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
 /* Expose. */
 module.exports = code;
-var codeBlockParamsMapping = [null, 'hl_lines=', 'linenostart='];
 
-var defaultMacro = function defaultMacro(content, lang, attrs) {
+var defaultMacro = function defaultMacro(content, lang) {
   // Default language is "text"
-  if (!lang) lang = 'text'; // Create a list of attributes to be serialized
-
-  var localCodeBlockParams = Array(codeBlockParamsMapping.length).fill(''); // Check for attributes and enumerate them
-
-  if (attrs !== null) {
-    for (var i = 0; i < codeBlockParamsMapping.length; i++) {
-      var _param = codeBlockParamsMapping[i]; // Skip unwanted parameters
-
-      if (_param === null) continue;
-      var location = attrs.indexOf(_param); // Parse the attributes we know
-
-      if (location > -1) {
-        var begin = location + _param.length;
-        var remaining = attrs.slice(begin);
-        var length = remaining.indexOf(' ');
-        var value = length > -1 ? attrs.slice(begin, begin + length) : remaining; // Remove string-delimiters
-
-        if (value.startsWith('"') && value.endsWith('"') || value.startsWith("'") && value.endsWith("'")) {
-          value = value.slice(1, -1).trim();
-        } // For hl_lines, we parse the parameters to ensure we don't have
-        // inverted ranges.
-
-
-        if (_param === 'hl_lines=') {
-          var hlItems = value.split(/,| /);
-
-          var _iterator = _createForOfIteratorHelper(hlItems.entries()),
-              _step;
-
-          try {
-            for (_iterator.s(); !(_step = _iterator.n()).done;) {
-              var _step$value = _slicedToArray(_step.value, 2),
-                  _i = _step$value[0],
-                  item = _step$value[1];
-
-              if (!item.includes('-')) {
-                continue;
-              }
-
-              var n = item.split('-').map(function (n) {
-                return parseInt(n);
-              }).filter(function (n) {
-                return !isNaN(n);
-              });
-
-              if (n.length !== 2) {
-                continue;
-              }
-
-              hlItems[_i] = "".concat(Math.min(n[0], n[1]), "-").concat(Math.max(n[0], n[1]));
-            }
-          } catch (err) {
-            _iterator.e(err);
-          } finally {
-            _iterator.f();
-          }
-
-          value = hlItems.join(',');
-        }
-
-        localCodeBlockParams[i] = value;
-      }
-    }
-  } // If we matched something, return optional arguments
-  // Note that we do stop serialization on a chain of empty arguments
-
-
-  var matched = localCodeBlockParams.reduce(function (a, v, i) {
-    return v !== '' ? i : a;
-  }, -1) + 1;
-  var param = matched > 0 ? "[".concat(localCodeBlockParams.slice(0, matched).join(']['), "]") : '';
-  return "\\begin{CodeBlock}".concat(param, "{").concat(lang, "}\n").concat(content, "\n\\end{CodeBlock}\n\n");
+  if (!lang) lang = 'text';
+  return "\\begin{CodeBlock}{".concat(lang, "}\n").concat(content, "\n\\end{CodeBlock}\n\n");
 };
 /* Stringify a code `node`. */
 
 
 function code(ctx, node) {
   var macro = ctx.code || defaultMacro;
-  return "".concat(macro(node.value, node.lang, node.meta, node));
+  return "".concat(macro(node.value, node.lang, node.meta));
 }
 
 code.macro = defaultMacro;

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -1,80 +1,17 @@
 /* Expose. */
 module.exports = code
 
-const codeBlockParamsMapping = [
-  null,
-  'hl_lines=',
-  'linenostart=',
-]
-
-const defaultMacro = (content, lang, attrs) => {
+const defaultMacro = (content, lang) => {
   // Default language is "text"
   if (!lang) lang = 'text'
 
-  // Create a list of attributes to be serialized
-  const localCodeBlockParams = Array(codeBlockParamsMapping.length).fill('')
-
-  // Check for attributes and enumerate them
-  if (attrs !== null) {
-    for (let i = 0; i < codeBlockParamsMapping.length; i++) {
-      const param = codeBlockParamsMapping[i]
-      // Skip unwanted parameters
-      if (param === null) continue
-      const location = attrs.indexOf(param)
-
-      // Parse the attributes we know
-      if (location > -1) {
-        const begin = location + param.length
-        const remaining = attrs.slice(begin)
-        const length = remaining.indexOf(' ')
-        let value = length > -1 ? attrs.slice(begin, begin + length) : remaining
-
-        // Remove string-delimiters
-        if (
-          (value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))
-        ) {
-          value = value.slice(1, -1).trim()
-        }
-
-        // For hl_lines, we parse the parameters to ensure we don't have
-        // inverted ranges.
-        if (param === 'hl_lines=') {
-          const hlItems = value.split(/,| /)
-
-          for (const [i, item] of hlItems.entries()) {
-            if (!item.includes('-')) {
-              continue
-            }
-
-            const n = item.split('-').map(n => parseInt(n)).filter(n => !isNaN(n))
-            if (n.length !== 2) {
-              continue
-            }
-
-            hlItems[i] = `${Math.min(n[0], n[1])}-${Math.max(n[0], n[1])}`
-          }
-
-          value = hlItems.join(',')
-        }
-
-        localCodeBlockParams[i] = value
-      }
-    }
-  }
-
-  // If we matched something, return optional arguments
-  // Note that we do stop serialization on a chain of empty arguments
-  const matched = localCodeBlockParams.reduce((a, v, i) => v !== '' ? i : a, -1) + 1
-  const param = matched > 0 ? `[${localCodeBlockParams.slice(0, matched).join('][')}]` : ''
-
-  return `\\begin{CodeBlock}${param}{${lang}}\n${content}\n\\end{CodeBlock}\n\n`
+  return `\\begin{CodeBlock}{${lang}}\n${content}\n\\end{CodeBlock}\n\n`
 }
 
 /* Stringify a code `node`. */
 function code (ctx, node) {
   const macro = ctx.code || defaultMacro
-  return `${macro(node.value, node.lang, node.meta, node)}`
+  return `${macro(node.value, node.lang, node.meta)}`
 }
 
 code.macro = defaultMacro

--- a/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
@@ -51,6 +51,38 @@ print('bla')
 
 
 
+\\\\begin{CodeBlock}[][][10]{python}
+print('bla')
+print('bla')
+print('bla')
+\\\\end{CodeBlock}
+
+
+
+\\\\begin{CodeBlock}[][1,2][10]{python}
+print('bla')
+print('bla')
+print('bla')
+\\\\end{CodeBlock}
+
+
+
+\\\\begin{CodeBlock}[][2]{css}
+.tmp {
+  font-weight: bold;
+}
+\\\\end{CodeBlock}
+
+
+
+\\\\begin{CodeBlock}[][1,3]{css}
+.tmp {
+  font-weight: bold;
+}
+\\\\end{CodeBlock}
+
+
+
 \\\\begin{CodeBlock}{text}
 a code without lang
 \\\\end{CodeBlock}"

--- a/packages/zmarkdown/__tests__/latex-suite.test.js
+++ b/packages/zmarkdown/__tests__/latex-suite.test.js
@@ -184,6 +184,30 @@ test('code', () => {
     print('bla')
     \`\`\`
 
+    \`\`\`python linenostart=10
+    print('bla')
+    print('bla')
+    print('bla')
+    \`\`\`
+
+    \`\`\`python hl_lines=1,2 linenostart=10
+    print('bla')
+    print('bla')
+    print('bla')
+    \`\`\`
+
+    \`\`\`css hl_lines="2"
+    .tmp {
+      font-weight: bold;
+    }
+    \`\`\`
+
+    \`\`\`css hl_lines='1,3'
+    .tmp {
+      font-weight: bold;
+    }
+    \`\`\`
+
     \`\`\`
     a code without lang
     \`\`\`

--- a/packages/zmarkdown/config/latex/index.js
+++ b/packages/zmarkdown/config/latex/index.js
@@ -62,6 +62,7 @@ const rebberConfig = {
   },
   codeAppendiceTitle:          'Annexes',
   appendiceReferenceGenerator: (appendixIndex) => `Annexe de code ${appendixIndex}`,
+  code:                        require('../../utils/latex-code'),
   customBlocks:                {
     map: {
       error:       'Error',
@@ -80,7 +81,7 @@ const rebberConfig = {
     image:       (node) => `\\image{${node.url}}`,
   },
   figure: {
-    image: (_, caption, extra) => `\\image{${extra.url}}${caption ? `[${caption}]` : ''}\n`,
+    image: (_1, _2, caption, extra) => `\\image{${extra.url}}${caption ? `[${caption}]` : ''}\n`,
   },
   headings: [
     (val) => `\\levelOneTitle{${val}}\n`,

--- a/packages/zmarkdown/plugins/remark-code-meta.js
+++ b/packages/zmarkdown/plugins/remark-code-meta.js
@@ -1,0 +1,73 @@
+// A word of caution: this plugin is non-standard
+// as regard to the MDAST specification.
+// Indeed, it transforms `meta` from `string?`
+// to `object` for code blocks.
+
+// The goal of this plugin is to be able to parse
+// meta information only once for HTML and LaTeX.
+
+const visit = require('unist-util-visit')
+const attrsParser = require('md-attr-parser')
+
+module.exports = parseCodeMeta
+
+function parseCodeMeta () {
+  // Normalize ranges for hl_lines
+  const rangeNormalize = range => {
+    let normalizedRange = ''
+
+    let previousNumber = -1
+    let currentNumber = ''
+
+    // Insert a number or range in the list
+    function insert () {
+      if (previousNumber >= 0) {
+        const currentInt = parseInt(currentNumber)
+        const previousInt = parseInt(previousNumber)
+
+        const minLineNumber = Math.min(currentInt, previousInt)
+        const maxLineNumber = Math.max(currentInt, previousInt)
+
+        normalizedRange += `${minLineNumber}-${maxLineNumber} `
+      } else {
+        normalizedRange += `${parseInt(currentNumber)} `
+      }
+    }
+
+    for (let charIndex = 0; charIndex < range.length; charIndex++) {
+      const currentChar = range[charIndex]
+      const currentCharCode = range.charCodeAt(charIndex)
+
+      // Match 0-9
+      if (currentCharCode >= 48 && currentCharCode <= 57) {
+        currentNumber += currentChar
+      } else if (currentChar === '-') {
+        previousNumber = parseInt(currentNumber)
+        currentNumber = ''
+      } else if (currentChar === ' ' || currentChar === ',') {
+        insert()
+
+        previousNumber = -1
+        currentNumber = ''
+      }
+    }
+
+    // Parse the last property if any
+    if (currentNumber) insert()
+
+    return normalizedRange.trim()
+  }
+
+  return (tree) => {
+    visit(tree, 'code', mutateCodeNode)
+  }
+
+  function mutateCodeNode (node) {
+    const attrs = attrsParser(node.meta || '').prop
+
+    const linenostart = parseInt(attrs.linenostart) || 1
+    const hlLines = rangeNormalize(attrs.hl_lines || '')
+
+    node.meta = {linenostart, hlLines}
+  }
+}

--- a/packages/zmarkdown/renderers/mdast.js
+++ b/packages/zmarkdown/renderers/mdast.js
@@ -8,6 +8,7 @@ const defaultTokenizerList = {
   abbr:                 require('remark-abbr/src'),
   alignBlocks:          require('remark-align/src'),
   captions:             require('remark-captions/src'),
+  codeMeta:             require('../plugins/remark-code-meta'),
   comments:             require('remark-comments/src'),
   customBlocks:         require('remark-custom-blocks/src'),
   emoticons:            require('remark-emoticons/src'),
@@ -16,6 +17,7 @@ const defaultTokenizerList = {
   gridTables:           require('remark-grid-tables/src'),
   headingShifter:       require('remark-heading-shift/src'),
   iframes:              require('remark-iframes/src'),
+  imageToFigure:        require('../plugins/remark-image-to-figure'),
   imagesDownload:       require('remark-images-download/src'),
   kbd:                  require('remark-kbd/src'),
   math:                 require('remark-math'),
@@ -24,7 +26,6 @@ const defaultTokenizerList = {
   subSuper:             require('remark-sub-super/src'),
   textr:                require('../plugins/remark-textr'),
   trailingSpaceHeading: require('remark-heading-trailing-spaces'),
-  imageToFigure:        require('../plugins/remark-image-to-figure'),
 }
 
 const postProcessorList = {

--- a/packages/zmarkdown/utils/code-handler.js
+++ b/packages/zmarkdown/utils/code-handler.js
@@ -76,7 +76,7 @@ const rangeHandler = range => {
 
 function code (_, node) {
   const value = node.value ? `${node.value}\n` : ''
-  const lang = node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)
+  const lang = (node.lang && node.lang.match(/^[^ \t]+(?=[ \t]|$)/)) || 'text'
   const attrs = node.meta
 
   const hlLines = rangeHandler(attrs.hlLines)

--- a/packages/zmarkdown/utils/latex-code.js
+++ b/packages/zmarkdown/utils/latex-code.js
@@ -1,0 +1,30 @@
+const customCodeMacro = (content, lang, attrs) => {
+  // Default language is "text"
+  if (!lang) lang = 'text'
+
+  const hasHlLines = (attrs && attrs.hlLines && attrs.hlLines !== [])
+  const hasLinenostart = (attrs && attrs.linenostart && attrs.linenostart !== 1)
+
+  let params = ''
+
+  // Optional caption is not used
+  if (hasHlLines || hasLinenostart) {
+    params += '[]'
+  }
+
+  // Line highlight
+  if (hasHlLines) {
+    params += `[${attrs.hlLines.split(' ').join(',')}]`
+  } else if (hasLinenostart) {
+    params += '[]'
+  }
+
+  if (hasLinenostart) {
+    params += `[${attrs.linenostart}]`
+  }
+
+  return `\\begin{CodeBlock}${params}{${lang}}\n${content}\n\\end{CodeBlock}\n\n`
+}
+
+/* Expose. */
+module.exports = customCodeMacro


### PR DESCRIPTION
fixes:  #417 

Recent changes to improve HTML code unfortunately had no effect on LaTeX, leading to some bugs such as the one cited above.
In order to fix the problem, I took a kinda complicated path; the idea is that our `code` stringifier for `rebber` was a bit too specific and ZdS-related, so I replaced it by a generic one, and moved the specific ZdS part into `zmarkdown`.

From then, I decided to move the currently HTML-specific part of the stringification into a separate `remark` plugin, so that the changes could be used both by HTML and LaTeX. After all this had been done, I cherry-picked #421 because it would otherwise have failed to merge.

Note: this requires a breaking change for `rebber` AND `rebber-plugin`, but not necessarily for `zmarkdown`, as it still renders as before, with an added bugfix.