### PR TITLE
[remark-disable-tokenizers] Fix #412

### DIFF
--- a/packages/remark-disable-tokenizers/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-disable-tokenizers/__tests__/__snapshots__/index.js.snap
@@ -36,6 +36,11 @@ exports[`inline 1`] = `
 
 exports[`inline throws 1`] = `"nope"`;
 
+exports[`regression: actually turn off the tokenizer #412 1`] = `
+"<p>hello
+world</p>"
+`;
+
 exports[`unknown tokenizer 1`] = `
 "<p><em>a</em></p>
 <blockquote>

--- a/packages/remark-disable-tokenizers/__tests__/index.js
+++ b/packages/remark-disable-tokenizers/__tests__/index.js
@@ -208,3 +208,21 @@ test('unknown tokenizer', () => {
 
   expect(contents).toMatchSnapshot()
 })
+
+test('regression: actually turn off the tokenizer #412', () => {
+  const {contents} = unified()
+    .use(reParse)
+    .use(plugin, {
+      block: [
+        ['html'],
+      ],
+      inline: [
+        ['html'],
+      ],
+    })
+    .use(remark2rehype)
+    .use(stringify)
+    .processSync(`hello\nworld`)
+
+  expect(contents).toMatchSnapshot()
+})

--- a/packages/remark-disable-tokenizers/dist/index.js
+++ b/packages/remark-disable-tokenizers/dist/index.js
@@ -3,7 +3,11 @@
 var clone = require('clone');
 
 var noop = function noop() {
-  return true;
+  return false;
+};
+
+var noopLocator = function noopLocator() {
+  return -1;
 };
 
 var throwing = function throwing(msg) {
@@ -61,6 +65,7 @@ function plugin() {
       }
 
       _this.Parser.prototype.inlineTokenizers[tokenizerName] = replacer;
+      _this.Parser.prototype.inlineTokenizers[tokenizerName].locator = noopLocator;
     });
   }
 }

--- a/packages/remark-disable-tokenizers/src/index.js
+++ b/packages/remark-disable-tokenizers/src/index.js
@@ -1,6 +1,7 @@
 const clone = require('clone')
 
-const noop = () => true
+const noop = () => false
+const noopLocator = () => -1
 
 const throwing = (msg) =>
   () => {
@@ -47,6 +48,7 @@ function plugin ({block = [], inline = []} = {}) {
             })
         }
         this.Parser.prototype.inlineTokenizers[tokenizerName] = replacer
+        this.Parser.prototype.inlineTokenizers[tokenizerName].locator = noopLocator
       })
   }
 }


### PR DESCRIPTION
fixes: #412 

`remark-disabled-tokenizers` replaces a tokenizer by `() => false` instead of `() => true`, and also adds a dummy locator for inline tokenizers.