### PR TITLE
[zmarkdown] Fix introduction/conclusion shifts

### DIFF
--- a/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
@@ -165,6 +165,31 @@ exports[`Texfile endpoint escapes title and author 1`] = `
 \\\\end{document}"
 `;
 
+exports[`Texfile endpoint shifts titles and only titles 1`] = `
+"\\\\documentclass[contentType]{zmdocument}
+
+\\\\usepackage{blindtext}
+\\\\title{The Title}
+\\\\author{FØØ, Bär}
+\\\\licence[/tmp/l/by-nc-sa.svg]{CC-BY-NC-SA}{https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode}
+
+\\\\smileysPath{/tmp/s}
+\\\\makeglossaries
+
+\\\\begin{document}
+\\\\maketitle
+\\\\tableofcontents
+
+\\\\levelThreeTitle{myTitle}
+
+\\\\begin{LevelOneIntroduction}
+myIntro
+\\\\end{LevelOneIntroduction}
+
+
+\\\\end{document}"
+`;
+
 exports[`Texfile endpoint transform quizzes for document 1`] = `
 "\\\\documentclass[contentType]{zmdocument}
 

--- a/packages/zmarkdown/__tests__/server.test.js
+++ b/packages/zmarkdown/__tests__/server.test.js
@@ -425,6 +425,24 @@ describe('Texfile endpoint', () => {
     expect(content).toContain('LevelThreeIntroduction')
     expect(content).toContain('LevelThreeConclusion')
   })
+
+  it('shifts titles and only titles', async () => {
+    const opts = clone(texfileOpts)
+    const manifest = {
+      introduction: 'myIntro',
+      title:        'myTitle',
+    }
+
+    opts.heading_shift = 2
+
+    const response = await a.post(texfile, {md: manifest, opts})
+    expect(response.status).toBe(200)
+
+    const [content] = response.data
+    expect(content).toMatchSnapshot()
+    expect(content).toContain('LevelOneIntroduction')
+    expect(content).toContain('levelThreeTitle')
+  })
 })
 
 

--- a/packages/zmarkdown/server/factories/config-factory.js
+++ b/packages/zmarkdown/server/factories/config-factory.js
@@ -71,7 +71,7 @@ module.exports = opts => {
     if (['introduction', 'conclusion'].includes(opts.extract_type)) {
       mdastConfig.postProcessors.wrapIntroCcl = {
         type:  opts.extract_type,
-        level: opts.heading_shift || 0,
+        level: opts.ic_shift || 0,
       }
     }
   }

--- a/packages/zmarkdown/server/factories/controller-factory.js
+++ b/packages/zmarkdown/server/factories/controller-factory.js
@@ -32,11 +32,16 @@ module.exports = (givenProc, template) => (req, res) => {
   // Get a collection of Promises to execute
   if (manifestRender) {
     extractPromises = manifest
-      .gatherExtracts(rawContent, baseShift)
+      .gatherExtracts(rawContent)
       .map(extract => {
         // Manifest rendering requires forging a new processor
         // to handle title depths
         const {text, options: localOptions} = extract
+        if (localOptions.depth) {
+          localOptions.heading_shift = baseShift + localOptions.depth
+          localOptions.ic_shift = localOptions.depth
+        }
+
         const mergedOptions = Object.assign({}, options, localOptions)
         const processor = processorFactory(givenProc, mergedOptions, true)
 

--- a/packages/zmarkdown/server/utils/manifest.js
+++ b/packages/zmarkdown/server/utils/manifest.js
@@ -15,8 +15,8 @@ const listConcatUnique = (a, b) => {
 const executeOnExtracts = (children, execFunction, depth = 0) => {
   function changeIfReturn (obj, extractType, d) {
     const r = execFunction(obj[extractType], {
-      extract_type:  extractType,
-      heading_shift: d,
+      extract_type: extractType,
+      depth:        d,
     })
     if (typeof r === 'string') obj[extractType] = r
   }
@@ -50,7 +50,7 @@ const metadataPropertiesRules = {
   ping:       listConcatUnique,
 }
 
-manifestUtils.gatherExtracts = (manifest, baseShift) => {
+manifestUtils.gatherExtracts = manifest => {
   const rawExtracts = []
 
   const appendToExtracts = (text, options = {}) => {
@@ -58,7 +58,7 @@ manifestUtils.gatherExtracts = (manifest, baseShift) => {
   }
 
   // Start recursion by top-level element
-  executeOnExtracts([manifest], appendToExtracts, baseShift)
+  executeOnExtracts([manifest], appendToExtracts)
 
   return rawExtracts
 }
@@ -115,7 +115,7 @@ manifestUtils.dispatch = (parsedExtracts, originalManifest) => {
 
   // Replace each extract where it belongs
   let i = 0
-  executeOnExtracts([finalManifest], () => parsedExtracts[i++].contents, 0)
+  executeOnExtracts([finalManifest], () => parsedExtracts[i++].contents)
 
   assembledExtracts.contents = finalManifest
   return assembledExtracts


### PR DESCRIPTION
Send request to endpoint `/latex-document`

```json
{
	"md": {
		"introduction": "myIntro",
		"title":        "myTitle",
		"children":     [{"introduction": "shiftedIntro"}]
	},
	"opts": {
		"content_type": "article",
		"title": "Heloo!",
		"authors": ["TALONE"],
		"license": "cc-by",
		"license_directory": "/home/zaphod",
		"smileys_directory": "/home/smileys",
		"heading_shift": 2
	}
}
```

You get `levelThreeTitle` (as expected because of the heading shift), but also `LevelThreeIntroduction`, which isn't expected. This PR solves the problem and restore the expected behavior.