### PR TITLE
[zmarkdown] Fix footnotes random postfix

### DIFF
--- a/packages/zmarkdown/config/html/index.js
+++ b/packages/zmarkdown/config/html/index.js
@@ -22,7 +22,7 @@ module.exports = {
 
   sanitize: require('../sanitize'),
 
-  postfixFootnotes: `-${shortid.generate()}`,
+  postfixFootnotes: (agg) => `${agg}-${shortid.generate()}`,
 
   postProcessors: {
     iframeWrappers:   require('./iframe-wrappers'),


### PR DESCRIPTION
Launch a ZMarkdown server, and try to launch multiple requests with Markdown containing footnotes.
All of these request will lead to the same footnote postfix id.

This is a really bad behavior as these ids are supposed to allow to distinguish between footnotes.
It must be present since version 9.0.0 (refactoring).