### PR TITLE
[zmarkdown] Fix footnotes random postfix (the return)

### DIFF
--- a/packages/zmarkdown/common.js
+++ b/packages/zmarkdown/common.js
@@ -33,10 +33,15 @@ module.exports = (
     parser.use(processor, processorConfig)
   }
 
+  // Regenerate footnotes postfix on extracts
+  const doRegenerate = (processor === 'html' && processorConfig._regenerateFootnotePostfix)
+  const regenerator = processorConfig._regenerateFootnotePostfix
+
   return (input, cb) => {
     if (typeof cb !== 'function') {
       return new Promise((resolve, reject) =>
         parser.process(input, (err, vfile) => {
+          if (doRegenerate) regenerator()
           if (err) return reject(err)
 
           resolve(vfile)
@@ -44,6 +49,7 @@ module.exports = (
     }
 
     parser.process(input, (err, vfile) => {
+      if (doRegenerate) regenerator()
       if (err) return cb(err)
 
       cb(null, vfile)

--- a/packages/zmarkdown/config/html/index.js
+++ b/packages/zmarkdown/config/html/index.js
@@ -1,5 +1,7 @@
 const shortid = require('shortid')
 
+let currentFootnotePostfix = shortid.generate()
+
 module.exports = {
   autolinkHeadings: {
     behaviour: 'append',
@@ -22,7 +24,11 @@ module.exports = {
 
   sanitize: require('../sanitize'),
 
-  postfixFootnotes: (agg) => `${agg}-${shortid.generate()}`,
+  postfixFootnotes: (agg) => `${agg}-${currentFootnotePostfix}`,
+
+  _regenerateFootnotePostfix: () => {
+    currentFootnotePostfix = shortid.generate()
+  },
 
   postProcessors: {
     iframeWrappers:   require('./iframe-wrappers'),


### PR DESCRIPTION
Followup PR for #431 : we were not regenerating postfixes for footnotes at all, now we are regenerating them too much, causing the reference to not match the definition.

Because that issue was too stupid to happen again, I added a test to check three things:

- for a footnote, the reference id matches the definition id;
- on a complete content, the second footnote id matches the first;
- **but** when two separate calls are made, the id changes.

Introducing that global variable inside the configuration file should not be a problem with multi-instances, because everything is kept separately (I checked it).