### PR TITLE
[remark-ping] Improve parsing to support Unicode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Force NPM version 6
+        run: npm install -g npm@6
+
       - name: Install global dependencies
         run: npm install -g pm2
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, all the plugins provided only work for remark versions **lesser than*
 
 ### Prerequisites
 
-* node >= 10
+* node >= 12
 * npm >= 6
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently, all the plugins provided only work for remark versions **lesser than*
 ### Prerequisites
 
 * node >= 12
-* npm >= 6
+* 7 > npm >= 6
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4090,6 +4090,11 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
+    "@unicode/unicode-13.0.0": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@unicode/unicode-13.0.0/-/unicode-13.0.0-1.1.0.tgz",
+      "integrity": "sha512-iOVqHDBzYSb4EOLBirZM9qNur+J7hAb6YyzGlUoAFx2ubb3Qidc+VhAuRQAxnOOWEqMcIZpnVnJ/OkTxbNmgEA=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -14404,6 +14409,7 @@
     "remark-ping": {
       "version": "file:packages/remark-ping",
       "requires": {
+        "@unicode/unicode-13.0.0": "^1.1.0",
         "unist-util-visit": "^2.0.3"
       }
     },

--- a/packages/remark-ping/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-ping/__tests__/__snapshots__/index.js.snap
@@ -7,6 +7,14 @@ exports[`compiles to Markdown 1`] = `
 }"
 `;
 
+exports[`fixture suite 0 compiles to HTML: h0 1`] = `
+"<p>ping @Clem</p>
+<p>ping @<strong>FOO BAR</strong></p>
+<p>no ping @quxjhdshqjkhfyhefezhjzjhdsjlfjlsqjdfjhsd</p>
+<p>ping <a href=\\"http://example.com\\"><span class=\\"ping ping-in-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></span></a></p>
+<p><a href=\\"/membres/voir/baz baz/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">baz baz</span></a></p>"
+`;
+
 exports[`fixture suite 0 compiles to Markdown: m0 1`] = `
 "ping @Clem
 
@@ -345,6 +353,23 @@ Object {
   },
   "type": "root",
 }
+`;
+
+exports[`fixture suite 1 compiles to HTML: h1 1`] = `
+"<h2>Test ping <a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></h2>
+<blockquote>
+<blockquote>
+<p>no metadata output <a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></p>
+</blockquote>
+</blockquote>
+<blockquote>
+<p>no metadata output <a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></p>
+</blockquote>
+<p>ping <a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></p>
+<p>ping <em><a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></em></p>
+<blockquote>
+<p>no metadata output <a href=\\"/membres/voir/I AM CLEM/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">I AM CLEM</span></a></p>
+</blockquote>"
 `;
 
 exports[`fixture suite 1 compiles to Markdown: m1 1`] = `
@@ -965,6 +990,14 @@ Object {
 }
 `;
 
+exports[`fixture suite 2 compiles to HTML: h2 1`] = `
+"<p><a href=\\"/membres/voir/foo/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">foo</span></a> <a href=\\"/membres/voir/bar/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">bar</span></a></p>
+<p>@baz baz</p>
+<blockquote>
+<p><a href=\\"/membres/voir/baz baz/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">baz baz</span></a></p>
+</blockquote>"
+`;
+
 exports[`fixture suite 2 compiles to Markdown: m2 1`] = `
 "@foo @bar
 
@@ -1230,6 +1263,270 @@ Object {
       "column": 15,
       "line": 5,
       "offset": 35,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`fixture suite 3 compiles to HTML: h3 1`] = `
+"<p><a href=\\"/membres/voir/Moté/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Moté</span></a> @Phigger</p>
+<p><a href=\\"/membres/voir/Phigger Moté/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Phigger Moté</span></a></p>
+<p>@Digitals@m <a href=\\"/membres/voir/Digitals@m/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Digitals@m</span></a></p>"
+`;
+
+exports[`fixture suite 3 compiles to Markdown: m3 1`] = `
+"@Moté @Phigger
+
+@**Phigger Moté**
+
+@Digitals@m @**Digitals@m**
+"
+`;
+
+exports[`fixture suite 3 parses: f3 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "@",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Moté",
+                },
+              ],
+              "data": Object {
+                "hName": "span",
+                "hProperties": Object {
+                  "class": "ping-username",
+                },
+              },
+              "type": "emphasis",
+            },
+          ],
+          "data": Object {
+            "hName": "a",
+            "hProperties": Object {
+              "class": "ping ping-link",
+              "href": "/membres/voir/Moté/",
+              "rel": "nofollow",
+            },
+          },
+          "position": Position {
+            "end": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "ping",
+          "url": "/membres/voir/Moté/",
+          "username": "Moté",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+              "offset": 14,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 6,
+              "line": 1,
+              "offset": 5,
+            },
+          },
+          "type": "text",
+          "value": " @Phigger",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+          "offset": 14,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "@",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Phigger Moté",
+                },
+              ],
+              "data": Object {
+                "hName": "span",
+                "hProperties": Object {
+                  "class": "ping-username",
+                },
+              },
+              "type": "emphasis",
+            },
+          ],
+          "data": Object {
+            "hName": "a",
+            "hProperties": Object {
+              "class": "ping ping-link",
+              "href": "/membres/voir/Phigger Moté/",
+              "rel": "nofollow",
+            },
+          },
+          "position": Position {
+            "end": Object {
+              "column": 18,
+              "line": 3,
+              "offset": 33,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 3,
+              "offset": 16,
+            },
+          },
+          "type": "ping",
+          "url": "/membres/voir/Phigger Moté/",
+          "username": "Phigger Moté",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 18,
+          "line": 3,
+          "offset": 33,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 3,
+          "offset": 16,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 13,
+              "line": 5,
+              "offset": 47,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 5,
+              "offset": 35,
+            },
+          },
+          "type": "text",
+          "value": "@Digitals@m ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "@",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Digitals@m",
+                },
+              ],
+              "data": Object {
+                "hName": "span",
+                "hProperties": Object {
+                  "class": "ping-username",
+                },
+              },
+              "type": "emphasis",
+            },
+          ],
+          "data": Object {
+            "hName": "a",
+            "hProperties": Object {
+              "class": "ping ping-link",
+              "href": "/membres/voir/Digitals@m/",
+              "rel": "nofollow",
+            },
+          },
+          "position": Position {
+            "end": Object {
+              "column": 28,
+              "line": 5,
+              "offset": 62,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 13,
+              "line": 5,
+              "offset": 47,
+            },
+          },
+          "type": "ping",
+          "url": "/membres/voir/Digitals@m/",
+          "username": "Digitals@m",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 28,
+          "line": 5,
+          "offset": 62,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 5,
+          "offset": 35,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 28,
+      "line": 5,
+      "offset": 62,
     },
     "start": Object {
       "column": 1,

--- a/packages/remark-ping/__tests__/index.js
+++ b/packages/remark-ping/__tests__/index.js
@@ -13,6 +13,9 @@ const mockUsernames = [
   'foo',
   'bar',
   'baz baz',
+  'Moté',
+  'Phigger Moté',
+  'Digitals@m',
 ]
 
 function pingUsername (username) {
@@ -21,7 +24,6 @@ function pingUsername (username) {
 function userURL (username) {
   return `/membres/voir/${username}/`
 }
-
 
 const remark = text => unified()
   .use(reParse)
@@ -74,50 +76,12 @@ const fixtures = [
 
     > @**baz baz**
   `,
-]
+  dedent`
+    @Moté @Phigger
 
-const outputs = [
-  dedent`
-    <p>ping @Clem</p>
-    <p>ping @<strong>FOO BAR</strong></p>
-    <p>no ping @quxjhdshqjkhfyhefezhjzjhdsjlfjlsqjdfjhsd</p>
-    <p>ping <a href="http://example.com"><span class="ping ping-in-link">\
-    @<span class="ping-username">I AM CLEM</span></span></a></p>
-    <p><a href="/membres/voir/baz baz/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">baz baz</span></a></p>
-  `,
-  dedent`
-    <h2>Test ping <a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></h2>
-    <blockquote>
-    <blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></p>
-    </blockquote>
-    </blockquote>
-    <blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></p>
-    </blockquote>
-    <p>ping <a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></p>
-    <p>ping <em><a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></em></p>
-    <blockquote>
-    <p>no metadata output <a href="/membres/voir/I AM CLEM/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">I AM CLEM</span></a></p>
-    </blockquote>
-  `,
-  dedent `
-    <p><a href="/membres/voir/foo/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">foo</span></a> \
-    <a href="/membres/voir/bar/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">bar</span></a></p>
-    <p>@baz baz</p>
-    <blockquote>
-    <p><a href="/membres/voir/baz baz/" rel="nofollow" class="ping ping-link">\
-    @<span class="ping-username">baz baz</span></a></p>
-    </blockquote>
+    @**Phigger Moté**
+
+    @Digitals@m @**Digitals@m**
   `,
 ]
 
@@ -125,8 +89,8 @@ const pings = [
   ['I AM CLEM', 'baz baz'],
   ['I AM CLEM', 'I AM CLEM', 'I AM CLEM'],
   ['foo', 'bar'],
+  ['Moté', 'Phigger Moté', 'Digitals@m'],
 ]
-
 
 fixtures.forEach((fixture, i) => {
   describe(`fixture suite ${i}`, () => {
@@ -143,7 +107,7 @@ fixtures.forEach((fixture, i) => {
     test('compiles to HTML', () => {
       return expect(
         toHTML(fixture).then(vfile => vfile.contents)
-      ).resolves.toBe(outputs[i])
+      ).resolves.toMatchSnapshot(`h${i}`)
     })
 
     test('compiles to Markdown', () => {

--- a/packages/remark-ping/dist/index.js
+++ b/packages/remark-ping/dist/index.js
@@ -2,27 +2,74 @@
 
 var visit = require('unist-util-visit');
 
+var interruptPunctuation = [require('@unicode/unicode-13.0.0/Binary_Property/White_Space/code-points'), require('@unicode/unicode-13.0.0/General_Category/Close_Punctuation/code-points'), require('@unicode/unicode-13.0.0/General_Category/Final_Punctuation/code-points'), require('@unicode/unicode-13.0.0/General_Category/Initial_Punctuation/code-points'), require('@unicode/unicode-13.0.0/General_Category/Open_Punctuation/code-points'), require('@unicode/unicode-13.0.0/General_Category/Other_Punctuation/code-points')].flat();
+
+var isInterrupt = function isInterrupt(c) {
+  return interruptPunctuation.includes(c.charCodeAt(0));
+};
+
+var containsInterrupt = function containsInterrupt(str) {
+  for (var c = 0; c < str.length; c++) {
+    var _char = str.charAt(c);
+
+    if (isInterrupt(_char)) return true;
+  }
+
+  return false;
+};
+
 var helpMsg = "remark-ping: expected configuration to be passed: {\n  pingUsername: (username) => bool,\n  userURL: (username) => string\n}";
 
 module.exports = function plugin(_ref) {
   var pingUsername = _ref.pingUsername,
       userURL = _ref.userURL,
-      _ref$usernameRegex = _ref.usernameRegex,
-      usernameRegex = _ref$usernameRegex === void 0 ? /@(?:\*\*([^*]+)\*\*|(\w+))/ : _ref$usernameRegex;
+      _ref$pingCharacter = _ref.pingCharacter,
+      pingCharacter = _ref$pingCharacter === void 0 ? '@' : _ref$pingCharacter,
+      _ref$fencedStartSeque = _ref.fencedStartSequence,
+      fencedStartSequence = _ref$fencedStartSeque === void 0 ? '**' : _ref$fencedStartSeque,
+      _ref$fencedEndSequenc = _ref.fencedEndSequence,
+      fencedEndSequence = _ref$fencedEndSequenc === void 0 ? '**' : _ref$fencedEndSequenc;
 
   if (typeof pingUsername !== 'function' || typeof userURL !== 'function') {
     throw new Error(helpMsg);
   }
 
   function inlineTokenizer(eat, value, silent) {
-    var keep = usernameRegex.exec(value);
-    if (!keep || keep.index > 0) return;
-    var total = keep[0];
-    var username = keep[2] ? keep[2] : keep[1];
+    var isFenced = false;
+    var eaten = pingCharacter;
+    var username = '';
+    var c = 1;
+    /* istanbul ignore if - never used (yet) */
+
+    if (silent) return silent;
+    if (value.charAt(0) !== pingCharacter) return; // Check if we have a fenced sequence
+
+    if (value.substring(1).startsWith(fencedStartSequence)) {
+      eaten += fencedStartSequence;
+      isFenced = true;
+      c += 2;
+    } // Iterate until:
+    //   - end of string;
+    //   - interrupt character for unfenced pings;
+    //   - trailing sequence for fenced pings.
+
+
+    while (value.charAt(c)) {
+      if (!isFenced && isInterrupt(value.charAt(c))) break;
+      if (isFenced && value.substring(c - 2).startsWith(fencedEndSequence) && isInterrupt(value.charAt(c))) break;
+      username += value.charAt(c++);
+    }
+
+    eaten += username; // Remove trailing sequence
+
+    if (isFenced) {
+      if (!username.endsWith(fencedEndSequence)) return;
+      username = username.slice(0, -fencedEndSequence.length);
+    }
 
     if (pingUsername(username) === true) {
       var url = userURL(username);
-      return eat(total)({
+      return eat(eaten)({
         type: 'ping',
         username: username,
         url: url,
@@ -52,21 +99,15 @@ module.exports = function plugin(_ref) {
         }]
       });
     } else {
-      return eat(total[0])({
+      return eat(eaten.charAt(0))({
         type: 'text',
-        value: total[0]
+        value: eaten.charAt(0)
       });
     }
   }
 
   function locator(value, fromIndex) {
-    var keep = usernameRegex.exec(value, fromIndex);
-
-    if (keep) {
-      return value.indexOf('@', keep.index);
-    }
-
-    return -1;
+    return value.indexOf('@', fromIndex);
   }
 
   inlineTokenizer.locator = locator;
@@ -82,11 +123,11 @@ module.exports = function plugin(_ref) {
     var visitors = Compiler.prototype.visitors;
 
     visitors.ping = function (node) {
-      if (!node.username.includes(' ')) {
-        return "@".concat(node.username);
+      if (!containsInterrupt(node.username)) {
+        return pingCharacter + node.username;
       }
 
-      return "@**".concat(node.username, "**");
+      return pingCharacter + fencedStartSequence + node.username + fencedEndSequence;
     };
   }
 

--- a/packages/remark-ping/package.json
+++ b/packages/remark-ping/package.json
@@ -9,7 +9,8 @@
   "contributors": [
     "Sébastien (AmarOk) Blin <contact@enconn.fr>",
     "François (artragis) Dambrine <perso@francoisdambrine.me>",
-    "Victor Felder <victor@draft.li> (https://draft.li)"
+    "Victor Felder <victor@draft.li> (https://draft.li)",
+    "Titouan (Stalone) S. <talone@boxph.one>"
   ],
   "scripts": {
     "pretest": "eslint .",

--- a/packages/remark-ping/package.json
+++ b/packages/remark-ping/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@unicode/unicode-13.0.0": "^1.1.0",
     "unist-util-visit": "^2.0.3"
   }
 }

--- a/packages/zmarkdown/config/mdast/index.js
+++ b/packages/zmarkdown/config/mdast/index.js
@@ -52,9 +52,8 @@ module.exports = {
   },
 
   ping: {
-    pingUsername:  (_username) => true,
-    userURL:       (username) => `/@${username}`,
-    usernameRegex: /\B@(?:\*\*([^*]+)\*\*|(\w+))/,
+    pingUsername: (_username) => true,
+    userURL:      (username) => `/@${username}`,
   },
 
   postProcessors: {

--- a/packages/zmarkdown/package.json
+++ b/packages/zmarkdown/package.json
@@ -34,7 +34,7 @@
     "release": "parallel-webpack"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@pm2/io": "^4.3.5",


### PR DESCRIPTION
Rewrite almost entirely the parser in `remark-ping` to get better support for Unicode characters in non-fenced pings. For instance, to ping `Moté`, the most natural way would be `@**Moté**`, which didn't work before this PR.

The detection of a ping has been changed as follow:

- before, we used a RegEx, that matched only `\w` characters;
- now, the package contains a complete, RegEx-independant parser, that gets the end of a ping matching characters from Unicode categories *White Space*, *Close Puncutation*, *Final Punctuation*, *Initial Punctuation*, *Open Punctuation* and *Other Punctuation*.

These changes should also make it easier to switch the package to `micromark` soon, as it already consist of a state-machine.