### PR TITLE
[zmarkdown] Fixes Sentry error handling

### DIFF
--- a/packages/zmarkdown/server/index.js
+++ b/packages/zmarkdown/server/index.js
@@ -14,9 +14,8 @@ Sentry.init({
 
 const app = express()
 
-// Sentry error handling
+// Sentry request handling
 app.use(Sentry.Handlers.requestHandler())
-app.use(Sentry.Handlers.errorHandler())
 
 app.use(cors())
 
@@ -28,6 +27,9 @@ if (process.env.ZMD_ENV !== 'production') {
 // Depend on routers
 app.use('/', require('./routes/endpoints'))
 app.use('/munin', require('./routes/munin'))
+
+// Sentry error handling
+app.use(Sentry.Handlers.errorHandler())
 
 const server = app.listen(process.env.PORT || 27272, () => {
   const host = server.address().address


### PR DESCRIPTION
Quoting [Sentry's documentation](https://docs.sentry.io/platforms/node/guides/express/):

> The error handler must be before any other error middleware and after all controllers

I tried it on Zeste de Savoir's staging server using this custom route to generate an error:

```js
app.get("/debug-sentry", function mainHandler(req, res) {
  throw new Error("My first Sentry error!");
});
```

Currently, the error is logged in `.pm2/logs/` but not sent to Sentry. With these changes, it is logged and sent to Sentry.