### PR TITLE
Fixes a small typo

### DIFF
--- a/packages/zmarkdown/README.md
+++ b/packages/zmarkdown/README.md
@@ -201,7 +201,7 @@ Markdown to LaTeX
 ### URL
 
 ```
-POST http://localhost:27272/epub
+POST http://localhost:27272/latex
 ```
 
 ### Request `opts` values


### PR DESCRIPTION
Fixes a small typo in zmarkdown package's README.