### PR TITLE
Two fixes on V11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24834,7 +24834,7 @@
       }
     },
     "packages/rebber": {
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",
@@ -24846,7 +24846,7 @@
       }
     },
     "packages/rebber-plugins": {
-      "version": "4.2.2",
+      "version": "4.3.0",
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3",
@@ -24914,7 +24914,7 @@
       "license": "MIT"
     },
     "packages/remark-custom-blocks": {
-      "version": "2.5.1",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "space-separated-tokens": "^1.1.5"
@@ -25003,7 +25003,7 @@
       }
     },
     "packages/remark-images-download": {
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2",
@@ -25045,7 +25045,7 @@
       }
     },
     "packages/remark-ping": {
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@unicode/unicode-13.0.0": "^1.1.0",
@@ -25089,7 +25089,7 @@
       "license": "MIT"
     },
     "packages/zmarkdown": {
-      "version": "10.1.2",
+      "version": "11.0.0",
       "license": "MIT",
       "dependencies": {
         "@pm2/io": "^4.3.5",

--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -816,6 +816,14 @@ exports[`math 1`] = `
 
 hehe
 
+
+
+We also want escaping like so: $$ or like so:
+
+
+
+$\\\\frac{1}{2}$
+
 "
 `;
 

--- a/packages/rebber-plugins/__tests__/rebber.test.js
+++ b/packages/rebber-plugins/__tests__/rebber.test.js
@@ -27,6 +27,8 @@ const emoticonsConfig = {
   },
 }
 
+const mathEscape = require('../src/preprocessors/mathEscape')
+
 const integrationConfig = {
   preprocessors: {
     tableCell: require('../src/preprocessors/codeVisitor'),
@@ -36,6 +38,8 @@ const integrationConfig = {
       'secretCustomBlock',
     ]),
     heading: require('../src/preprocessors/headingVisitor'),
+    inlineMath: mathEscape,
+    math: mathEscape,
   },
   overrides: {
     abbr: require('../src/type/abbr'),
@@ -439,6 +443,10 @@ test('math', () => {
       $$
 
       hehe
+
+      We also want escaping like so: $\alphb$ or like so:
+
+      $$\ve\frac{1}{2}$$
     `)
   expect(contents).toMatchSnapshot()
 })

--- a/packages/rebber-plugins/dist/preprocessors/mathEscape.js
+++ b/packages/rebber-plugins/dist/preprocessors/mathEscape.js
@@ -7,8 +7,13 @@ module.exports = function () {
     var commandStart = node.value.indexOf('\\');
 
     while (commandStart !== -1) {
-      var commandEnd = node.value.substr(commandStart).search(/[{[\s]/);
-      var commandName = node.value.substr(commandStart, commandEnd); // Check for unknown commands
+      var commandEnd = node.value.substr(commandStart + 1).search(/[{[\s\\]/); // End not found is end of line
+
+      if (commandEnd === -1) {
+        commandEnd = node.value.length - 1;
+      }
+
+      var commandName = node.value.substr(commandStart, commandEnd + 1); // Check for unknown commands
 
       if (!katexConstants.includes(commandName)) {
         node.value = node.value.replace(commandName, ' ');

--- a/packages/rebber-plugins/src/preprocessors/mathEscape.js
+++ b/packages/rebber-plugins/src/preprocessors/mathEscape.js
@@ -4,8 +4,14 @@ module.exports = () => node => {
   let commandStart = node.value.indexOf('\\')
 
   while (commandStart !== -1) {
-    const commandEnd = node.value.substr(commandStart).search(/[{[\s]/)
-    const commandName = node.value.substr(commandStart, commandEnd)
+    let commandEnd = node.value.substr(commandStart + 1).search(/[{[\s\\]/)
+
+    // End not found is end of line
+    if (commandEnd === -1) {
+      commandEnd = node.value.length - 1
+    }
+
+    const commandName = node.value.substr(commandStart, commandEnd + 1)
 
     // Check for unknown commands
     if (!katexConstants.includes(commandName)) {

--- a/packages/remark-ping/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-ping/__tests__/__snapshots__/index.js.snap
@@ -1277,7 +1277,8 @@ Object {
 exports[`fixture suite 3 compiles to HTML: h3 1`] = `
 "<p><a href=\\"/membres/voir/Moté/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Moté</span></a> @Phigger</p>
 <p><a href=\\"/membres/voir/Phigger Moté/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Phigger Moté</span></a></p>
-<p>@Digitals@m <a href=\\"/membres/voir/Digitals@m/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Digitals@m</span></a></p>"
+<p>@Digitals@m <a href=\\"/membres/voir/Digitals@m/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">Digitals@m</span></a></p>
+<p><a href=\\"/membres/voir/empty/\\" rel=\\"nofollow\\" class=\\"ping ping-link\\">@<span class=\\"ping-username\\">empty</span></a> @</p>"
 `;
 
 exports[`fixture suite 3 compiles to Markdown: m3 1`] = `
@@ -1286,6 +1287,8 @@ exports[`fixture suite 3 compiles to Markdown: m3 1`] = `
 @**Phigger Moté**
 
 @Digitals@m @**Digitals@m**
+
+@empty @
 "
 `;
 
@@ -1521,12 +1524,94 @@ Object {
       },
       "type": "paragraph",
     },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "@",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "empty",
+                },
+              ],
+              "data": Object {
+                "hName": "span",
+                "hProperties": Object {
+                  "class": "ping-username",
+                },
+              },
+              "type": "emphasis",
+            },
+          ],
+          "data": Object {
+            "hName": "a",
+            "hProperties": Object {
+              "class": "ping ping-link",
+              "href": "/membres/voir/empty/",
+              "rel": "nofollow",
+            },
+          },
+          "position": Position {
+            "end": Object {
+              "column": 7,
+              "line": 7,
+              "offset": 70,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 7,
+              "offset": 64,
+            },
+          },
+          "type": "ping",
+          "url": "/membres/voir/empty/",
+          "username": "empty",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 9,
+              "line": 7,
+              "offset": 72,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 7,
+              "line": 7,
+              "offset": 70,
+            },
+          },
+          "type": "text",
+          "value": " @",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 9,
+          "line": 7,
+          "offset": 72,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 7,
+          "offset": 64,
+        },
+      },
+      "type": "paragraph",
+    },
   ],
   "position": Object {
     "end": Object {
-      "column": 28,
-      "line": 5,
-      "offset": 62,
+      "column": 9,
+      "line": 7,
+      "offset": 72,
     },
     "start": Object {
       "column": 1,

--- a/packages/remark-ping/__tests__/index.js
+++ b/packages/remark-ping/__tests__/index.js
@@ -16,6 +16,7 @@ const mockUsernames = [
   'Moté',
   'Phigger Moté',
   'Digitals@m',
+  'empty',
 ]
 
 function pingUsername (username) {
@@ -82,6 +83,8 @@ const fixtures = [
     @**Phigger Moté**
 
     @Digitals@m @**Digitals@m**
+
+    @empty @
   `,
 ]
 
@@ -89,7 +92,7 @@ const pings = [
   ['I AM CLEM', 'baz baz'],
   ['I AM CLEM', 'I AM CLEM', 'I AM CLEM'],
   ['foo', 'bar'],
-  ['Moté', 'Phigger Moté', 'Digitals@m'],
+  ['Moté', 'Phigger Moté', 'Digitals@m', 'empty'],
 ]
 
 fixtures.forEach((fixture, i) => {

--- a/packages/remark-ping/dist/index.js
+++ b/packages/remark-ping/dist/index.js
@@ -67,7 +67,7 @@ module.exports = function plugin(_ref) {
       username = username.slice(0, -fencedEndSequence.length);
     }
 
-    if (pingUsername(username) === true) {
+    if (pingUsername(username) === true && username.trim() !== '') {
       var url = userURL(username);
       return eat(eaten)({
         type: 'ping',

--- a/packages/remark-ping/src/index.js
+++ b/packages/remark-ping/src/index.js
@@ -72,7 +72,7 @@ module.exports = function plugin ({
       username = username.slice(0, -fencedEndSequence.length)
     }
 
-    if (pingUsername(username) === true) {
+    if (pingUsername(username) === true && username.trim() !== '') {
       const url = userURL(username)
 
       return eat(eaten)({

--- a/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
@@ -360,7 +360,7 @@ exports[`math 1`] = `
 
 
 
-This should be escaped: $\\\\pink{\\\\text{I love    {ls / > outputrce}  {outputrce}}}$.
+This should be escaped: $\\\\pink{\\\\text{I love     {ls / > outputrce}  {outputrce}}}$.
 
 
 


### PR DESCRIPTION
Fixes two bugs found when testing ZMdv11 on ZdS:

- math sanitation doesn't work on string end and on chained commands (eg. `\vec\frac{1}{2}`);
- empty pings generate a link.