### PR TITLE
[zmarkdown] Allow enforcing shifts (fixes #448)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24846,7 +24846,7 @@
       }
     },
     "packages/rebber-plugins": {
-      "version": "4.3.0",
+      "version": "4.3.2",
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3",
@@ -25045,7 +25045,7 @@
       }
     },
     "packages/remark-ping": {
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@unicode/unicode-13.0.0": "^1.1.0",
@@ -25089,7 +25089,7 @@
       "license": "MIT"
     },
     "packages/zmarkdown": {
-      "version": "11.0.0",
+      "version": "11.0.2",
       "license": "MIT",
       "dependencies": {
         "@pm2/io": "^4.3.5",

--- a/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
@@ -2,6 +2,11 @@
 
 exports[`HTML endpoint accepts POSTed markdown 1`] = `"<h3 id=\\"foo\\">foo<a aria-hidden=\\"true\\" tabindex=\\"-1\\" href=\\"#foo\\"><span class=\\"icon icon-link\\"></span></a></h3>"`;
 
+exports[`HTML endpoint can enforce shifting level 1`] = `
+"<h2 id=\\"i-have-seen-a-dolphin\\">I have seen a dolphin<a aria-hidden=\\"true\\" tabindex=\\"-1\\" href=\\"#i-have-seen-a-dolphin\\"><span class=\\"icon icon-link\\"></span></a></h2>
+<p>On a camera. What is happening with animals these days?\\"</p>"
+`;
+
 exports[`HTML endpoint correctly renders manifest 1`] = `
 Object {
   "children": Array [

--- a/packages/zmarkdown/__tests__/server.test.js
+++ b/packages/zmarkdown/__tests__/server.test.js
@@ -188,6 +188,21 @@ describe('HTML endpoint', () => {
     const [, metadata] = response.data
     expect(metadata.hasQuizz).toBe(true)
   })
+
+  it('can enforce shifting level', async () => {
+    const text = dedent(`
+    # I have seen a dolphin
+    
+    On a camera. What is happening with animals these days?"
+    `)
+
+    const response = await a.post(html, {md: text, opts: {heading_shift: 1, enforce_shift: true}})
+    expect(response.status).toBe(200)
+
+    const [content] = response.data
+    expect(content).toMatchSnapshot()
+    expect(content).toContain('h2')
+  })
 })
 
 describe('LaTeX endpoint', () => {

--- a/packages/zmarkdown/server/factories/controller-factory.js
+++ b/packages/zmarkdown/server/factories/controller-factory.js
@@ -42,8 +42,8 @@ module.exports = (givenProc, template) => (req, res) => {
           localOptions.ic_shift = localOptions.depth
         }
 
-        const mergedOptions = Object.assign({}, options, localOptions)
-        const processor = processorFactory(givenProc, mergedOptions, true)
+        const mergedOptions = Object.assign({enforce_shift: true}, options, localOptions)
+        const processor = processorFactory(givenProc, mergedOptions)
 
         return processor(text)
       })

--- a/packages/zmarkdown/server/factories/processor-factory.js
+++ b/packages/zmarkdown/server/factories/processor-factory.js
@@ -5,7 +5,7 @@ const zmd                 = require('../../common')
 // ZMd parser memoization
 const processors = {}
 
-module.exports = (processor, opts = {}, bypassHeadingShift = false) => {
+module.exports = (processor, opts = {}) => {
   if (!['epub', 'html', 'latex'].includes(processor)) {
     const error = new Error(`Unknown target '${processor}'`)
 
@@ -19,12 +19,12 @@ module.exports = (processor, opts = {}, bypassHeadingShift = false) => {
   }
 
   if (processor === 'html') {
-    if (!bypassHeadingShift) opts.heading_shift = 2
+    if (!opts.enforce_shift) opts.heading_shift = 2
     opts.disable_images_download = true
   }
 
   if (processor === 'latex') {
-    if (!bypassHeadingShift) opts.heading_shift = 0
+    if (!opts.enforce_shift) opts.heading_shift = 0
     opts.disable_ping = true
     opts.disable_jsfiddle = true
   } else {
@@ -32,7 +32,7 @@ module.exports = (processor, opts = {}, bypassHeadingShift = false) => {
   }
 
   if (processor === 'epub') {
-    if (!bypassHeadingShift) opts.heading_shift = 2
+    if (!opts.enforce_shift) opts.heading_shift = 2
     opts.disable_ping = true
     opts.disable_jsfiddle = true
     opts.inline = false


### PR DESCRIPTION
Fixes #448 

The solution involves adding an `enforce_shift` option to the API that can be used to make ZMarkdown follow `heading_shift` in all cases). This option is recommended, and will be the default behavior in the next major version.

What is done for now is to force `heading_shift=2` for HTML contents. This setting is mostly historical, but still needed by `zds-site` today. Changes are required before the next version.