### PR TITLE
[meta] Switch tests from Node 12 to Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  NODE_VERSION: "14"
+  NODE_VERSION: "16"
 
 jobs:
   lint:
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -55,6 +55,6 @@ jobs:
 
       - name: Update coverage report
         uses: coverallsapp/github-action@master
-        if: matrix.node-version == '14.x'
+        if: matrix.node-version == '16.x'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepublish.yml
+++ b/.github/workflows/prepublish.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 env:
-  NODE_VERSION: "14"
+  NODE_VERSION: "16"
 
 jobs:
 


### PR DESCRIPTION
Node 12 is not LTS anymore, but 18 is the active version. CI Build is not made on 16 instead of 14.