### PR TITLE
[rebber-plugins] Better math sanitation (fixes #471)

### DIFF
--- a/packages/rebber-plugins/dist/preprocessors/mathEscape.js
+++ b/packages/rebber-plugins/dist/preprocessors/mathEscape.js
@@ -7,19 +7,26 @@ module.exports = function () {
     var commandStart = node.value.indexOf('\\');
 
     while (commandStart !== -1) {
-      var commandEnd = node.value.substr(commandStart + 1).search(/[{[\s\\]/); // End not found is end of line
+      // Eat leading backslashes
+      var leadSlashes = 1;
 
-      if (commandEnd === -1) {
-        commandEnd = node.value.length - 1;
-      }
+      for (; node.value.charAt(commandStart + leadSlashes) === '\\'; leadSlashes++) {
+        ;
+      } // Find end of command
 
-      var commandName = node.value.substr(commandStart, commandEnd + 1); // Check for unknown commands
+
+      var potentialEnd = node.value.substr(commandStart + leadSlashes).search(/[{[\s\\]/); // Is end was not found, use end of line
+
+      var commandLength = potentialEnd === -1 ? node.value.length : leadSlashes + potentialEnd;
+      var commandName = node.value.substr(commandStart, commandLength); // Check for unknown commands
 
       if (!katexConstants.includes(commandName)) {
-        node.value = node.value.replace(commandName, ' ');
+        var beforeCommand = node.value.substring(0, commandStart);
+        var afterCommand = node.value.substring(commandStart + commandLength, node.value.length);
+        node.value = "".concat(beforeCommand, " ").concat(afterCommand);
       }
 
-      commandStart = node.value.indexOf('\\', commandStart + 1);
+      commandStart = node.value.indexOf('\\', commandStart + leadSlashes);
     } // Check count of brackets
 
 

--- a/packages/rebber-plugins/src/preprocessors/mathEscape.js
+++ b/packages/rebber-plugins/src/preprocessors/mathEscape.js
@@ -4,21 +4,27 @@ module.exports = () => node => {
   let commandStart = node.value.indexOf('\\')
 
   while (commandStart !== -1) {
-    let commandEnd = node.value.substr(commandStart + 1).search(/[{[\s\\]/)
+    // Eat leading backslashes
+    let leadSlashes = 1
+    for (; node.value.charAt(commandStart + leadSlashes) === '\\'; leadSlashes++);
 
-    // End not found is end of line
-    if (commandEnd === -1) {
-      commandEnd = node.value.length - 1
-    }
+    // Find end of command
+    const potentialEnd = node.value.substr(commandStart + leadSlashes).search(/[{[\s\\]/)
 
-    const commandName = node.value.substr(commandStart, commandEnd + 1)
+    // Is end was not found, use end of line
+    const commandLength = potentialEnd === -1 ? node.value.length : leadSlashes + potentialEnd
+
+    const commandName = node.value.substr(commandStart, commandLength)
 
     // Check for unknown commands
     if (!katexConstants.includes(commandName)) {
-      node.value = node.value.replace(commandName, ' ')
+      const beforeCommand = node.value.substring(0, commandStart)
+      const afterCommand = node.value.substring(commandStart + commandLength, node.value.length)
+
+      node.value = `${beforeCommand} ${afterCommand}`
     }
 
-    commandStart = node.value.indexOf('\\', commandStart + 1)
+    commandStart = node.value.indexOf('\\', commandStart + leadSlashes)
   }
 
   // Check count of brackets


### PR DESCRIPTION
**Bug**: fixes #471 .

**Identification**: double backslashes were treated as two simple backslashes one after the other, causing the sanitizer to delete *all backslashes* in the math block.

**Fix**: two complementary fixes are submitted:

- eat all leading backslashes of the command;
- do not replace in the full math content, but locally.