### PR TITLE
[zmarkdown] Allow specifying date on LaTeX files

### DIFF
--- a/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/server.test.js.snap
@@ -82,6 +82,26 @@ exports[`Texfile endpoint accepts POSTed markdown 1`] = `
 \\\\end{document}"
 `;
 
+exports[`Texfile endpoint allows date 1`] = `
+"\\\\documentclass[contentType]{zmdocument}
+
+\\\\usepackage{blindtext}
+\\\\title{The Title}
+\\\\author{FØØ, Bär}
+\\\\licence[/tmp/l/by-nc-sa.svg]{CC-BY-NC-SA}{https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode}
+\\\\date{2 mai 1998}
+\\\\smileysPath{/tmp/s}
+\\\\makeglossaries
+
+\\\\begin{document}
+\\\\maketitle
+\\\\tableofcontents
+
+\\\\levelOneTitle{foo}
+
+\\\\end{document}"
+`;
+
 exports[`Texfile endpoint allows extra arguments 1`] = `
 "\\\\documentclass[contentType]{zmdocument}
 

--- a/packages/zmarkdown/__tests__/server.test.js
+++ b/packages/zmarkdown/__tests__/server.test.js
@@ -324,6 +324,16 @@ describe('Texfile endpoint', () => {
     expect(result[0]).toMatchSnapshot()
   })
 
+  it('allows date', async () => {
+    const specificOptions = {date: '2 mai 1998'}
+    const response = await a.post(texfile,
+      {md: '# foo', opts: xtend(texfileOpts, specificOptions)})
+    expect(response.status).toBe(200)
+
+    const result = response.data
+    expect(result[0]).toMatchSnapshot()
+  })
+
   it('does not return metadata', async () => {
     const response = await a.post(texfile, {md: '# foo', opts: texfileOpts})
 

--- a/packages/zmarkdown/server/templates/latex-document.js
+++ b/packages/zmarkdown/server/templates/latex-document.js
@@ -17,6 +17,7 @@ module.exports = opts => {
     title,
     authors,
     license,
+    date,
     latex,
   } = opts
   // Required options
@@ -33,6 +34,7 @@ module.exports = opts => {
 
   // Optional arguments
   const extraHeaders = []
+  if (date) extraHeaders.push(`\\date{${date}}`)
   if (logoDirectory && contentLogo) extraHeaders.push(`\\logo{${logoDirectory}/${contentLogo}}`)
   if (logoDirectory && editorLogo) extraHeaders.push(`\\editorLogo{${logoDirectory}/${editorLogo}}`)
   if (contentLink) extraHeaders.push(`\\tutoLink{${contentLink}}`)


### PR DESCRIPTION
Add an endpoint option on `latex-document` to specify the publication date of a content.