### PR TITLE
Multiple images in figure

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Two images in figure 1`] = `
+"\\\\inlineImage{img1.png}
+\\\\inlineImage{img2.png}
+Figure: Common text
+
+"
+`;
+
 exports[`abbr 1`] = `
 "HELO to you
 

--- a/packages/rebber-plugins/__tests__/fixtures/figure.fixture.md
+++ b/packages/rebber-plugins/__tests__/fixtures/figure.fixture.md
@@ -19,3 +19,7 @@ Sam |   38
 Alice  |   35
 Mathilde  | 35
 Table: Coucou
+
+![alt text1](img1.png)
+![alt text2](img2.png)
+Figure: Common text

--- a/packages/remark-captions/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-captions/__tests__/__snapshots__/index.js.snap
@@ -7,6 +7,8 @@ exports[`#101 1`] = `
 <p><a href=\\"#\\"></a></p>"
 `;
 
+exports[`Two images in figure 1`] = `"<figure><img src=\\"img1.png\\" alt=\\"alt text1\\"><img src=\\"img2.png\\" alt=\\"alt text2\\"><figcaption>Common text</figcaption></figure>"`;
+
 exports[`caption without block 1`] = `
 "<pre><code class=\\"language-python\\">print('bla')
 </code></pre>

--- a/packages/remark-captions/__tests__/index.js
+++ b/packages/remark-captions/__tests__/index.js
@@ -324,6 +324,15 @@ test('compiles to markdown when no caption', () => {
 
   expect(contents1).toBe(contents2)
 })
+test('Two images in figure', () => {
+  const md = dedent`
+    ![alt text1](img1.png)
+    ![alt text2](img2.png)
+    Figure: Common text
+  `
+  const {contents} = render(md)
+  expect(contents).toMatchSnapshot()
+})
 test('compiles to markdown when at least 1 block caption', () => {
   const md = dedent`
     foo

--- a/packages/remark-captions/dist/index.js
+++ b/packages/remark-captions/dist/index.js
@@ -115,6 +115,12 @@ function internLegendVisitor(internalBlocks) {
     });
 
     if (legendChildIndex === -1 || !node.children && legendChildIndex < index) {
+      if (node.type === 'image' && parent.children[0].type === 'figure') {
+        var captionIndex = parent.children[0].children.length - 1;
+        parent.children[0].children.splice(captionIndex, 0, clone(node));
+        parent.children.splice(index, 1);
+      }
+
       return;
     } // split the text node containing the last legend and find the line containing it
 

--- a/packages/remark-captions/src/index.js
+++ b/packages/remark-captions/src/index.js
@@ -110,6 +110,11 @@ function internLegendVisitor (internalBlocks) {
     if (legendChildIndex === -1 ||
       (!node.children && legendChildIndex < index)
     ) {
+      if (node.type === 'image' && parent.children[0].type === 'figure') {
+        const captionIndex = parent.children[0].children.length - 1
+        parent.children[0].children.splice(captionIndex, 0, clone(node))
+        parent.children.splice(index, 1)
+      }
       return
     }
 


### PR DESCRIPTION
This PR intents to enable multiple images in figures

fix #479 

For now it only fails with rebber as plugin relies on the assumption there is only one image