### PR TITLE
[remark-captions] Add missing dependency 'xtend'

### DIFF
--- a/packages/remark-captions/package.json
+++ b/packages/remark-captions/package.json
@@ -30,6 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "clone": "^2.1.2",
-    "unist-util-visit": "^2.0.3"
+    "unist-util-visit": "^2.0.3",
+    "xtend": "^4.0.2"
   }
 }


### PR DESCRIPTION
Fixes the following error when using `remark-captions`:

```
Error: Cannot find module 'xtend'
Require stack:
- /path/to/node_modules/remark-captions/dist/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:995:15)
    at Function.Module._load (node:internal/modules/cjs/loader:841:27)
    at Module.require (node:internal/modules/cjs/loader:1067:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/path/to/node_modules/remark-captions/dist/index.js:7:13)
```