### PR TITLE
[rebber] Fix two security flaws

### DIFF
--- a/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
+++ b/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
@@ -843,6 +843,18 @@ exports[`rebber: remark specs code-block-escape: code-block-escape 1`] = `
 \\\\begin{CodeBlock}{python}
 
 
+\\\\end{CodeBlock}
+
+
+
+An ingenuous flaw:
+
+
+
+\\\\begin{CodeBlock}{text}
+
+\\\\input{/etc/passwd}
+\\\\begin{CodeBlock}{text}
 \\\\end{CodeBlock}"
 `;
 
@@ -2188,6 +2200,8 @@ exports[`rebber: remark specs image-in-link: image-in-link 1`] = `
 
 \\\\externalLink{\\\\includegraphics{https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square}}{http://example.com}"
 `;
+
+exports[`rebber: remark specs image-path-escape: image-path-escape 1`] = `"\\\\includegraphics{a[b]\\\\ \\\\input{/etc/passwd\\\\image{[a](b)}"`;
 
 exports[`rebber: remark specs image-with-pipe: image-with-pipe 1`] = `"f|"`;
 
@@ -7907,7 +7921,15 @@ exports[`rebber: remark specs with config: custom macros code-block-escape 1`] =
 
 
 [codePython(\\\\end{CodeBlock}
-\\\\end   {CodeBlock})]"
+\\\\end   {CodeBlock})]
+
+An ingenuous flaw:
+
+
+
+[code(\\\\end\\\\end{CodeBlock}{CodeBlock}
+\\\\input{/etc/passwd}
+\\\\begin{CodeBlock}{text})]"
 `;
 
 exports[`rebber: remark specs with config: custom macros code-block-indentation 1`] = `
@@ -8929,6 +8951,8 @@ exports[`rebber: remark specs with config: custom macros image-in-link 1`] = `
 
 \\\\externalLink{\\\\includegraphics{https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square}}{http://example.com}"
 `;
+
+exports[`rebber: remark specs with config: custom macros image-path-escape 1`] = `"\\\\includegraphics{a[b]\\\\ \\\\input{/etc/passwd\\\\image{[a](b)}"`;
 
 exports[`rebber: remark specs with config: custom macros image-with-pipe 1`] = `"f|"`;
 
@@ -13736,6 +13760,18 @@ exports[`toLaTeX: remark specs code-block-escape: code-block-escape 1`] = `
 
 \\\\end{CodeBlock}
 
+
+
+An ingenuous flaw:
+
+
+
+\\\\begin{CodeBlock}{text}
+
+\\\\input{/etc/passwd}
+\\\\begin{CodeBlock}{text}
+\\\\end{CodeBlock}
+
 "
 `;
 
@@ -15165,6 +15201,12 @@ exports[`toLaTeX: remark specs image-in-link: image-in-link 1`] = `
 
 
 \\\\externalLink{\\\\includegraphics{https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square}}{http://example.com}
+
+"
+`;
+
+exports[`toLaTeX: remark specs image-path-escape: image-path-escape 1`] = `
+"\\\\includegraphics{a[b]\\\\ \\\\input{/etc/passwd\\\\image{[a](b)}
 
 "
 `;

--- a/packages/rebber/__tests__/fixtures/code-block-escape.text
+++ b/packages/rebber/__tests__/fixtures/code-block-escape.text
@@ -4,3 +4,11 @@ A little flaw:
 \end{CodeBlock}
 \end   {CodeBlock}
 ```
+
+An ingenuous flaw:
+
+```
+\end\end{CodeBlock}{CodeBlock}
+\input{/etc/passwd}
+\begin{CodeBlock}{text}
+```

--- a/packages/rebber/__tests__/fixtures/image-path-escape.text
+++ b/packages/rebber/__tests__/fixtures/image-path-escape.text
@@ -1,0 +1,1 @@
+![](a}[b]\ \input{/etc/passwd}\image{[a](b))

--- a/packages/rebber/dist/types/code.js
+++ b/packages/rebber/dist/types/code.js
@@ -5,7 +5,13 @@ module.exports = code;
 
 var defaultMacro = function defaultMacro(content, lang) {
   // Escape CodeBlocks
-  var escaped = content.replace(new RegExp('\\\\end\\s*{CodeBlock}', 'g'), ''); // Default language is "text"
+  var escaped = content;
+  var escapeRegex = new RegExp('\\\\end\\s*{CodeBlock}', 'g');
+
+  while (escapeRegex.test(escaped)) {
+    escaped = escaped.replace(escapeRegex, '');
+  } // Default language is "text"
+
 
   if (!lang) lang = 'text';
   return "\\begin{CodeBlock}{".concat(lang, "}\n").concat(escaped, "\n\\end{CodeBlock}\n\n");

--- a/packages/rebber/src/types/code.js
+++ b/packages/rebber/src/types/code.js
@@ -3,7 +3,13 @@ module.exports = code
 
 const defaultMacro = (content, lang) => {
   // Escape CodeBlocks
-  const escaped = content.replace(new RegExp('\\\\end\\s*{CodeBlock}', 'g'), '')
+  let escaped = content
+
+  const escapeRegex = new RegExp('\\\\end\\s*{CodeBlock}', 'g')
+
+  while (escapeRegex.test(escaped)) {
+    escaped = escaped.replace(escapeRegex, '')
+  }
 
   // Default language is "text"
   if (!lang) lang = 'text'

--- a/packages/zmarkdown/utils/latex-code.js
+++ b/packages/zmarkdown/utils/latex-code.js
@@ -3,7 +3,15 @@ const customCodeMacro = (content, lang, attrs) => {
   if (!lang) lang = 'text'
 
   // Escape CodeBlocks
-  const escaped = content.replace(new RegExp('\\\\end\\s*{CodeBlock}', 'g'), '')
+  let escaped = content
+
+  const escapeRegex = new RegExp('\\\\end\\s*{CodeBlock}', 'g')
+
+  while (escapeRegex.test(escaped)) {
+    escaped = escaped.replace(escapeRegex, '')
+  }
+
+  // Detect features
   const hasHlLines = (attrs && attrs.hlLines && attrs.hlLines !== [])
   const hasLinenostart = (attrs && attrs.linenostart && attrs.linenostart !== 1)
 


### PR DESCRIPTION
1. An RCE was found in images: when an image path contained an `}`, the LaTeX image command could be bypassed to allow malicious code injection.
2. An RCE was found in code blocks: a previous protection measure was unsufficient, thus allowing code blocks to be escaped in LaTeX