### PR TITLE
Implement new table system (tabularray) for LaTeX 

### DIFF
--- a/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
+++ b/packages/rebber-plugins/__tests__/__snapshots__/rebber.test.js.snap
@@ -284,26 +284,22 @@ quote
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Nom & Age \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Fred & 39 \\\\\\\\ \\\\hline
-Sam & 38 \\\\\\\\ \\\\hline
-Alice & 35 \\\\\\\\ \\\\hline
-Mathilde & 35 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Nom & Age \\\\\\\\
+Fred & 39 \\\\\\\\
+Sam & 38 \\\\\\\\
+Alice & 35 \\\\\\\\
+Mathilde & 35 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Nom & Age \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Fred & 39 \\\\\\\\ \\\\hline
-Sam & 38 \\\\\\\\ \\\\hline
-Alice & 35 \\\\\\\\ \\\\hline
-Mathilde & 35 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Nom & Age \\\\\\\\
+Fred & 39 \\\\\\\\
+Sam & 38 \\\\\\\\
+Alice & 35 \\\\\\\\
+Mathilde & 35 \\\\\\\\
+\\\\end{longtblr}
 \\\\captionof{table}{Coucou}"
 `;
 
@@ -501,14 +497,12 @@ Figure: with an \\\\footnote[l124c17o2894]{inline footnote} in caption
 `;
 
 exports[`gridTable 1`] = `
-"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Sub & Headings & ABBR \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{ABBR   spanning}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Sub & Headings & ABBR \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} ABBR   spanning &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{longtblr}
 \\\\captionof{table}{The new table ABBR [\\\\textasciicircum{}foot] with ||CTRL|| + ||S||}
 
 
@@ -521,142 +515,116 @@ multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multi
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-title & image \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & image \\\\\\\\
+space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-title & code \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & code \\\\\\\\
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\
+block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
- & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+ & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
- & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
-a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
-e & f &  &  \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  &  \\\\\\\\
+ & F & \\\\SetCell[c=2]{l} G &  \\\\\\\\
+a & b & \\\\SetCell[r=2]{l} c   d \\\\endgraf \\\\endgraf g &  \\\\\\\\
+e & f &  &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{column[\\\\textasciicircum{}foot]}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=2,row{1,2}={font=\\\\bfseries}}
+\\\\SetCell[c=2]{l} Table Headings &  & Here \\\\\\\\
+Sub & Headings & Too \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} column[\\\\textasciicircum{}foot] &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
- & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+ & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
-\\\\rowfont[l]{}
- & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[r=3]{l} A & \\\\SetCell[c=2]{l} B &  \\\\\\\\
+ & C & D \\\\\\\\
+ & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[c=2]{l} E &  & \\\\SetCell[c=2]{l} F &  \\\\\\\\
+\\\\SetCell[c=4]{l} G &  &  &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[c=4]{l} A &  &  &  \\\\\\\\
+\\\\SetCell[c=2]{l} B &  & \\\\SetCell[c=2]{l} C &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
-Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
-K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
-Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
-Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+H & \\\\SetCell[c=16]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & He \\\\\\\\
+Li & Be & \\\\SetCell[r=2]{l}  &  &  &  &  &  &  &  &  &  & B & C & N & O & F & Ne \\\\\\\\
+Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\
+K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\
+Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\
+Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\
+Fr & Ra & ACT & \\\\SetCell[c=15]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=18]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=3]{l} Lanthanide &  &  & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\
+\\\\SetCell[c=3]{l} Actinide &  &  & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{longtblr}
 
 
 Text at the end
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{longtblr}
 
 
 Text at the
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} &  \\\\\\\\ \\\\cline{1-1}
-\\\\rowfont[l]{}
-b &  &  & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]}}
+a & \\\\SetCell[r=2]{l}  &  &  \\\\\\\\
+b &  &  & c \\\\\\\\
+\\\\end{longtblr}
 \\\\captionof{table}{multirow}
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 5 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 5 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 5 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 5 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 5 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{span}} & header & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{span}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-elem & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{span middle}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 5 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+\\\\SetCell[c=2]{l} span &  & header & \\\\SetCell[c=2]{l} span &  \\\\\\\\
+elem & \\\\SetCell[c=2]{l} span middle &  & \\\\SetCell[c=2]{l}  &  \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\begin{appendices}
@@ -1036,146 +1004,120 @@ exports[`mix-3 1`] = `
 `;
 
 exports[`mix-4 1`] = `
-"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} column spanning &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{longtblr}
 \\\\captionof{table}{The new table \\\\abbr{ABBR}{abbreviation} \\\\textsuperscript{\\\\protect\\\\footnotemark[foot]} with \\\\keys{CTRL} + \\\\keys{S}}
 
 
 
 \\\\footnotetext[foot]{a foot}
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-title & image \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & image \\\\\\\\
+space & \\\\inlineImage{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-title & code \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & code \\\\\\\\
+inline & \\\\texttt{inline} br \\\\endgraf \\\\texttt{inline} \\\\\\\\
+block & \\\\hyperref[appendix-1]{Code appendice 1} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
- & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+ & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} &  \\\\\\\\ \\\\cline{2-4}
- & F & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
-a & b & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{c   d \\\\endgraf \\\\endgraf g}} \\\\\\\\ \\\\cline{1-2}
-e & f &  &  \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  &  \\\\\\\\
+ & F & \\\\SetCell[c=2]{l} G &  \\\\\\\\
+a & b & \\\\SetCell[r=2]{l} c   d \\\\endgraf \\\\endgraf g &  \\\\\\\\
+e & f &  &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=2,row{1,2}={font=\\\\bfseries}}
+\\\\SetCell[c=2]{l} Table Headings &  & Here \\\\\\\\
+Sub & Headings & Too \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} column spanning &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
- & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+ & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
-\\\\rowfont[l]{}
- & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[r=3]{l} A & \\\\SetCell[c=2]{l} B &  \\\\\\\\
+ & C & D \\\\\\\\
+ & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[c=2]{l} E &  & \\\\SetCell[c=2]{l} F &  \\\\\\\\
+\\\\SetCell[c=4]{l} G &  &  &  \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[c=4]{l} A &  &  &  \\\\\\\\
+\\\\SetCell[c=2]{l} B &  & \\\\SetCell[c=2]{l} C &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
-Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
-K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
-Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
-Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+H & \\\\SetCell[c=16]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & He \\\\\\\\
+Li & Be & \\\\SetCell[r=2]{l}  &  &  &  &  &  &  &  &  &  & B & C & N & O & F & Ne \\\\\\\\
+Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\
+K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\
+Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\
+Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\
+Fr & Ra & ACT & \\\\SetCell[c=15]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=18]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=3]{l} Lanthanide &  &  & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\
+\\\\SetCell[c=3]{l} Actinide &  &  & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{longtblr}
 
 
 Text at the end
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{longtblr}
 
 
 Text at the
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} &  \\\\\\\\ \\\\cline{1-1}
-\\\\rowfont[l]{}
-b &  &  & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]}}
+a & \\\\SetCell[r=2]{l}  &  &  \\\\\\\\
+b &  &  & c \\\\\\\\
+\\\\end{longtblr}
 \\\\captionof{table}{multirow}
 
 
@@ -1211,12 +1153,10 @@ no caption"
 `;
 
 exports[`mix-7 1`] = `
-"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-cell & \\\\texttt{code with line break} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 2 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{\\\\hyperref[appendix-1]{Code appendice 1}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]}}
+cell & \\\\texttt{code with line break} \\\\\\\\
+\\\\SetCell[c=2]{l} \\\\hyperref[appendix-1]{Code appendice 1} &  \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\begin{appendices}
@@ -1361,34 +1301,28 @@ a
 `;
 
 exports[`table 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-1 & 2 & 3 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2  & 3 \\\\\\\\ \\\\hline
-1 & 2  & 3 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+1 & 2 & 3 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2  & 3 \\\\\\\\
+1 & 2  & 3 \\\\\\\\
+\\\\end{longtblr}
 
 
 Another test for inline image with overridden configuration:
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-c1 & c2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-c3 & \\\\inlineImage{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+c1 & c2 \\\\\\\\
+c3 & \\\\inlineImage{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\
+\\\\end{longtblr}"
 `;

--- a/packages/rebber-plugins/src/type/gridTable.js
+++ b/packages/rebber-plugins/src/type/gridTable.js
@@ -63,12 +63,11 @@ class GridTableStringifier {
     if (node.data && node.data.hProperties.rowSpan > 1) {
       this.currentSpan = node.data.hProperties.rowSpan
       this.multiLineCellIndex = this.colIndex
-      baseText = `\\multirow{${this.currentSpan}}{*}{\\parbox{\\linewidth}{${baseText}}}`
+      baseText = `\\SetCell[r=${this.currentSpan}]{l} ${baseText}`
       this.colSpan = node.data.hProperties.colSpan > 1 ? node.data.hProperties.colSpan : 1
     } else if (node.data && node.data.hProperties.colSpan > 1) {
       const colSpan = node.data.hProperties.colSpan
-      const colDim = `m{\\dimexpr(\\linewidth) * ${colSpan} / \\number-of-column - 2 * \\tabcolsep}`
-      baseText = `\\multicolumn{${colSpan}}{|${colDim}|}{\\parbox{\\linewidth}{${baseText}}}`
+      baseText = `\\SetCell[c=${colSpan}]{l} ${baseText}`
     }
 
     if (node.data && node.data.hProperties.colSpan > 1) {
@@ -81,22 +80,40 @@ class GridTableStringifier {
 
   gridTableRow (ctx, node, index) {
     const overriddenCtx = clone(ctx)
-    this.rowIndex++
     overriddenCtx.tableRow = undefined
+
+    this.rowIndex++
+
+    const extraCell = {
+      type: 'tableCell',
+      children: [{
+        type: 'paragraph',
+        children: [{
+          type: 'text',
+          value: ' '
+        }]
+      }]
+    }
+
+    // Duplicate cells with colSpan greater than one
+    for (let i = 0; i < node.children.length; i++) {
+      if (!node.children[i].data) continue
+
+      const colSpan = node.children[i].data.hProperties.colSpan
+      if (!colSpan || colSpan <= 1) continue
+
+      for (let j = 0; j < colSpan - 1; j++) {
+        node.children.splice(i + 1, 0, extraCell)
+      }
+    }
+
     if (this.previousRowWasMulti()) {
       const lastMultiRowline = this.flushMultiRowLineIfNeeded()
+
       for (let i = 0; i < lastMultiRowline.colSpan; i++) {
-        node.children.splice(lastMultiRowline.startCell - 1, 0, {
-          type: 'tableCell',
-          children: [{
-            type: 'paragraph',
-            children: [{
-              type: 'text',
-              value: ' '
-            }]
-          }]
-        })
+        node.children.splice(lastMultiRowline.startCell - 1, 0, extraCell)
       }
+
       this.colIndex = 0
       let rowStr = tableRow(overriddenCtx, node, index)
       if (lastMultiRowline.multilineCounter > 0) {
@@ -140,10 +157,15 @@ class GridTableStringifier {
     return row
   }
 
+  gridTableheaderCounter (node) {
+    const tableHeaders = node.children
+      .filter(n => n.data && n.data.hName === 'thead')
+
+    return tableHeaders.length >= 1 ? tableHeaders[0].children.length : 0
+  }
+
   gridTableHeaderParse () {
-    return `|m{\\dimexpr(\\linewidth) / ${this.nbOfColumns} - 2 * \\tabcolsep}`
-      .repeat(this.nbOfColumns)
-      .concat('|')
+    return ' X[-1]'.repeat(this.nbOfColumns).substring(1)
   }
 
   previousRowWasMulti () {
@@ -153,11 +175,12 @@ class GridTableStringifier {
 
 function gridTable (ctx, node) {
   const overriddenCtx = clone(ctx)
-  overriddenCtx.spreadCell = ''
   const stringifier = new GridTableStringifier()
-  overriddenCtx.break = () => ' \\endgraf' // in gridtables '\\\\' won't work
+  // Inside tables, `\\\\` won't work
+  overriddenCtx.break = () => ' \\endgraf'
   overriddenCtx.tableCell = stringifier.gridTableCell.bind(stringifier)
   overriddenCtx.tableRow = stringifier.gridTableRow.bind(stringifier)
+  overriddenCtx.headerCounter = stringifier.gridTableheaderCounter.bind(stringifier)
   overriddenCtx.headerParse = stringifier.gridTableHeaderParse.bind(stringifier)
 
   overriddenCtx.image = overriddenCtx.image ? overriddenCtx.image : {}

--- a/packages/rebber/README.md
+++ b/packages/rebber/README.md
@@ -156,36 +156,33 @@ will stringify our example Markdown to `[inserted image located at "/foo.png"]` 
 
     (ctx, node) => ``,
 
-To ensure a flexible rendering, `longtabu` environment is used by default.
 Table stringification can be configured with some advanced options:
 
-###### `options.spreadCell`
+###### `options.tableEnvName`
 
-` spread 0pt `
+    `longtblr`
 
-Customize cells spacing (usually done using the `spread` command).
-Common commands are ` spread <dimension> ` (add `<dimension>` as spacing ) or ` to <dimension> ` (fix the overall width of table).
-Default value is ` spread 0pt ` (natural spacing).
+Name of the environment to be used for tables.
+Allows defining custom environments in LaTeX with `\NewTblrEnviron`.
+To ensure a flexible rendering, the `longtblr` environment is used by default.
 
-###### `options.firstLineRowFont`
+###### `options.headerCounter: (node) => 1`
 
-`'\\rowfont[c]{\\bfseries}'`
+    (tableRows) => 1
 
-Customize the first line font (this is useful when your tables always have a header as first line).
-Default value is `'\\rowfont[c]{\\bfseries}'` (bold, center aligned).
+Function that counts the number of header rows (rows that should be emphasized).
 
-###### `options.defaultOtherLineRowFont`
+###### `options.headerProperties`
 
-`'\\rowfont[l]{}'`
+    `font=\bfseries`
 
-Customize table font for all lines except the first.
-Default value is `'\\rowfont[l]{}'` (normal font, left aligned).
+LaTeX properties added to header rows, follows the syntax of the underlying LaTeX package.
 
-###### `options.headerParse: (tableRows) => ''`
+###### `options.headerParse`
 
-    (tableRows) => ''
+    (tableRows) => ``
 
-Cunction that computes the "latex header" part of the table environment, this generates strings such as `|c|c|r|`.
+Function that computes the "latex header" part of the table environment, this generates strings such as `|c|c|r|`.
 It gets an array of all the `tableRow` [mdast] nodes for the table as argument.
 Default function extracts the number of columns for each row and uses the `X[-1]` handler ("find the best available width").
 The result for a 3 column-table is `|X[-1]|X[-1]|X[-1]|`.

--- a/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
+++ b/packages/rebber/__tests__/__snapshots__/mdast.tests.js.snap
@@ -6282,12 +6282,10 @@ Pipes should not be escaped here: |
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-here & they \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-should & tho|ugh \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+here & they \\\\\\\\
+should & tho|ugh \\\\\\\\
+\\\\end{longtblr}
 
 
 And here:
@@ -6375,22 +6373,18 @@ exports[`rebber: remark specs strong-initial-white-space: strong-initial-white-s
 `;
 
 exports[`rebber: remark specs table: table 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\begin{CodeBlock}{text}
@@ -6399,64 +6393,52 @@ Test code
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-empty-initial-cell: table-empty-initial-cell 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
- & a & c \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-a & b & c \\\\\\\\ \\\\hline
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+ & a & c \\\\\\\\
+a & b & c \\\\\\\\
+a & b & c \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-escaped-pipes: table-escaped-pipes 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-First & Second & third \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-first & second & third \\\\\\\\ \\\\hline
-first & second | second & third | \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First & Second & third \\\\\\\\
+first & second & third \\\\\\\\
+first & second | second & third | \\\\\\\\
+first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\
+first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-in-list: table-in-list 1`] = `
 "\\\\begin{itemize}
 \\\\item\\\\relax Unordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 \\\\item\\\\relax Ordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 \\\\end{itemize}"
 `;
 
@@ -6491,32 +6473,27 @@ Invalid characters:
 `;
 
 exports[`rebber: remark specs table-loose: table-loose 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-no-body: table-no-body 1`] = `
 "\\\\part{Foo}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Name & GitHub & Twitter \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Name & GitHub & Twitter \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-no-end-of-line: table-no-end-of-line 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-foo & bar \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+foo & bar \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-one-column: table-one-column 1`] = `
@@ -6524,12 +6501,10 @@ exports[`rebber: remark specs table-one-column: table-one-column 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-b \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a \\\\\\\\
+b \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-one-row: table-one-row 1`] = `
@@ -6537,56 +6512,47 @@ exports[`rebber: remark specs table-one-row: table-one-row 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a & b & c \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-padded: table-padded 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-pipes-in-code: table-pipes-in-code 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` &  &  & \` \\\\\\\\ \\\\hline
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` &  &  & \` \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-spaced: table-spaced 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs table-with-image: table-with-image 1`] = `
@@ -6594,12 +6560,10 @@ exports[`rebber: remark specs table-with-image: table-with-image 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-c1 & c2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+c1 & c2 \\\\\\\\
+c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs tabs: tabs 1`] = `
@@ -6952,20 +6916,18 @@ exports[`rebber: remark specs title-attributes: title-attributes 1`] = `
 "\\\\part{Links}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\
+Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\chapter{Double quotes}
@@ -12150,12 +12112,10 @@ Pipes should not be escaped here: |
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-here & they \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-should & tho|ugh \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+here & they \\\\\\\\
+should & tho|ugh \\\\\\\\
+\\\\end{longtblr}
 
 
 And here:
@@ -12238,82 +12198,66 @@ exports[`rebber: remark specs with config: custom macros strong-initial-white-sp
 `;
 
 exports[`rebber: remark specs with config: custom macros table 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}
 
 
 [code(Test code)]
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-empty-initial-cell 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
- & a & c \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-a & b & c \\\\\\\\ \\\\hline
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+ & a & c \\\\\\\\
+a & b & c \\\\\\\\
+a & b & c \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-escaped-pipes 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-First & Second & third \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-first & second & third \\\\\\\\ \\\\hline
-first & second | second & third | \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First & Second & third \\\\\\\\
+first & second & third \\\\\\\\
+first & second | second & third | \\\\\\\\
+first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\
+first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-in-list 1`] = `
 "[unorderedList([listItem(Unordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu})][listItem(Ordered:
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr})][listItem(Ordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu})])]"
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr})])]"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-invalid-alignment 1`] = `
@@ -12345,31 +12289,26 @@ Invalid characters:
 `;
 
 exports[`rebber: remark specs with config: custom macros table-loose 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-no-body 1`] = `
 "heading1(Foo)
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Name & GitHub & Twitter \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Name & GitHub & Twitter \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-no-end-of-line 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-foo & bar \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+foo & bar \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-one-column 1`] = `
@@ -12377,12 +12316,10 @@ exports[`rebber: remark specs with config: custom macros table-one-column 1`] = 
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-b \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a \\\\\\\\
+b \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-one-row 1`] = `
@@ -12390,56 +12327,47 @@ exports[`rebber: remark specs with config: custom macros table-one-row 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a & b & c \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-padded 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-pipes-in-code 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` &  &  & \` \\\\\\\\ \\\\hline
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` &  &  & \` \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-spaced 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros table-with-image 1`] = `
@@ -12447,12 +12375,10 @@ exports[`rebber: remark specs with config: custom macros table-with-image 1`] = 
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-c1 & c2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+c1 & c2 \\\\\\\\
+c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\
+\\\\end{longtblr}"
 `;
 
 exports[`rebber: remark specs with config: custom macros tabs 1`] = `
@@ -12664,20 +12590,18 @@ exports[`rebber: remark specs with config: custom macros tidyness 1`] = `
 exports[`rebber: remark specs with config: custom macros title-attributes 1`] = `
 "heading1(Links)
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\
+Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\
+\\\\end{longtblr}
 
 
 heading2(Double quotes)
@@ -19423,12 +19347,10 @@ Pipes should not be escaped here: |
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-here & they \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-should & tho|ugh \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+here & they \\\\\\\\
+should & tho|ugh \\\\\\\\
+\\\\end{longtblr}
 
 
 And here:
@@ -19525,22 +19447,18 @@ exports[`toLaTeX: remark specs strong-initial-white-space: strong-initial-white-
 `;
 
 exports[`toLaTeX: remark specs table: table 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Heading 1 & \\\\textbf{H}eading 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+Cell 5 & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\begin{CodeBlock}{text}
@@ -19549,46 +19467,38 @@ Test code
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 & Header 3 & Header 4 \\\\\\\\
+Cell 1 & Cell 2 & Cell 3 & Cell 4 \\\\\\\\
+\\\\textit{Cell 5} & Cell 6 & Cell 7 & Cell 8 \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-empty-initial-cell: table-empty-initial-cell 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
- & a & c \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-a & b & c \\\\\\\\ \\\\hline
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+ & a & c \\\\\\\\
+a & b & c \\\\\\\\
+a & b & c \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-escaped-pipes: table-escaped-pipes 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-First & Second & third \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-first & second & third \\\\\\\\ \\\\hline
-first & second | second & third | \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\ \\\\hline
-first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First & Second & third \\\\\\\\
+first & second & third \\\\\\\\
+first & second | second & third | \\\\\\\\
+first & second \\\\textbackslash{} & third \\\\textbackslash{} \\\\\\\\
+first & second \\\\textbackslash{}| second & third \\\\textbackslash{}| \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -19596,20 +19506,16 @@ exports[`toLaTeX: remark specs table-in-list: table-in-list 1`] = `
 "\\\\begin{itemize}
 \\\\item\\\\relax Unordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 \\\\item\\\\relax Ordered:
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-A & B \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 \\\\end{itemize}
 "
 `;
@@ -19647,13 +19553,11 @@ Invalid characters:
 `;
 
 exports[`toLaTeX: remark specs table-loose: table-loose 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -19661,20 +19565,17 @@ exports[`toLaTeX: remark specs table-no-body: table-no-body 1`] = `
 "\\\\part{Foo}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Name & GitHub & Twitter \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Name & GitHub & Twitter \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-no-end-of-line: table-no-end-of-line 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-foo & bar \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+foo & bar \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -19683,12 +19584,10 @@ exports[`toLaTeX: remark specs table-one-column: table-one-column 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-b \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a \\\\\\\\
+b \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -19697,59 +19596,50 @@ exports[`toLaTeX: remark specs table-one-row: table-one-row 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-a & b & c \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+a & b & c \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-padded: table-padded 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-pipes-in-code: table-pipes-in-code 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` &  &  & \` \\\\\\\\ \\\\hline
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` &  &  & \` \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-abc & head2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-x & \` \\\\\\\\ \\\\hline
-x & \` & \` \\\\\\\\ \\\\hline
-x & \\\\texttt{f} \\\\\\\\ \\\\hline
-x & \`\`\`\` \\\\\\\\ \\\\hline
-x & \`\\\\texttt{f} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+abc & head2 \\\\\\\\
+x & \` \\\\\\\\
+x & \` & \` \\\\\\\\
+x & \\\\texttt{f} \\\\\\\\
+x & \`\`\`\` \\\\\\\\
+x & \`\\\\texttt{f} \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
 exports[`toLaTeX: remark specs table-spaced: table-spaced 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Header 1 & Header 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Cell 1 & Cell 2 \\\\\\\\ \\\\hline
-Cell 3 & Cell 4 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Header 1 & Header 2 \\\\\\\\
+Cell 1 & Cell 2 \\\\\\\\
+Cell 3 & Cell 4 \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -19758,12 +19648,10 @@ exports[`toLaTeX: remark specs table-with-image: table-with-image 1`] = `
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-c1 & c2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+c1 & c2 \\\\\\\\
+c3 & \\\\includegraphics{https://zestedesavoir.com/media/galleries/426/56dc4a1e-416b-4a9d-830d-95b45d58a17a.png} \\\\\\\\
+\\\\end{longtblr}
 "
 `;
 
@@ -20128,20 +20016,18 @@ exports[`toLaTeX: remark specs title-attributes: title-attributes 1`] = `
 "\\\\part{Links}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[c]{\\\\bfseries}
-Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\ \\\\hline
-Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\ \\\\hline
-CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{longtblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Implementation & Characters & Nested & Mismatched & Escaped & Named Entities & Numbered Entities \\\\\\\\
+Markdown.pl & \\\\texttt{\\"} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{\\"} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{\\"} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{'} & Yes & Yes & No & Yes & Yes \\\\\\\\
+GitHub & \\\\texttt{'} & Yes & Yes & No & No & No \\\\\\\\
+CommonMark & \\\\texttt{'} & No & No & Yes & Yes & Yes \\\\\\\\
+Markdown.pl & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+GitHub & \\\\texttt{()} & - & - & - & - & - \\\\\\\\
+CommonMark & \\\\texttt{()} & No & Yes & Yes & Yes & Yes \\\\\\\\
+\\\\end{longtblr}
 
 
 \\\\chapter{Double quotes}

--- a/packages/rebber/dist/types/table.js
+++ b/packages/rebber/dist/types/table.js
@@ -7,17 +7,31 @@ const one = require('../one');
 module.exports = table;
 const defaultHeaderParse = rows => {
   const columns = Math.max(...rows.map(l => l.split('&').length));
-  const colHeader = `|${'X[-1]|'.repeat(columns)}`;
-  return colHeader;
+  return ' X[-1]'.repeat(columns).substring(1);
+};
+
+// Retrocompatibility: first row is always header on default tables
+const defaultheaderCounter = () => {
+  return 1;
 };
 const defaultMacro = (ctx, node) => {
   const headerParse = ctx.headerParse ? ctx.headerParse : defaultHeaderParse;
+  const headerCounter = ctx.headerCounter ? ctx.headerCounter : defaultheaderCounter;
   const parsed = node.children.map((n, index) => one(ctx, n, index, node));
-  const inner = parsed.join('');
+  const headerCount = headerCounter(node);
   const colHeader = headerParse(parsed);
-  const spreadCell = typeof ctx.spreadCell === 'string' ? ctx.spreadCell : ' spread 0pt ';
+  const envName = typeof ctx.tableEnvName === 'string' ? ctx.tableEnvName : 'longtblr';
   const caption = node.caption ? `\n\\captionof{table}{${node.caption}}\n` : '';
-  return `\\begin{longtabu}${spreadCell}{${colHeader}} \\hline\n${inner}\\end{longtabu}${caption}\n`;
+  // eslint-disable-next-line max-len
+  const headerProperties = typeof ctx.headerProperties === 'string' ? ctx.headerProperties : 'font=\\bfseries';
+  let extraProps = '';
+  if (headerCount && headerCount > 0) {
+    const tableHeaderEnum = new Array(headerCount).fill(0).map((_, i) => i + 1).join(',');
+    extraProps += `,rowhead=${headerCount},row{${tableHeaderEnum}}={${headerProperties}}`;
+  }
+
+  // eslint-disable-next-line max-len
+  return `\\begin{${envName}}{colspec={${colHeader}}${extraProps}}\n${parsed.join('')}\\end{${envName}}${caption}\n`;
 };
 
 /* Stringify a table `node`. */

--- a/packages/rebber/dist/types/tableRow.js
+++ b/packages/rebber/dist/types/tableRow.js
@@ -7,21 +7,11 @@ const defaultMacro = (ctx, node) => {
   const parsed = [];
   node.children.map((n, index) => parsed.push(one(ctx, n, index, node)));
   const line = parsed.join(' & ');
-  return `${line} \\\\ \\hline\n`;
+  return `${line} \\\\\n`;
 };
-const defaultFirstLineRowFont = '\\rowfont[c]{\\bfseries}';
-const defaultOtherLineRowFont = '\\rowfont[l]{}';
 
 /* Stringify a tableRow `node`. */
 function tableRow(ctx, node, index) {
   const macro = ctx.tableRow || defaultMacro;
-  const firstLineRowFont = ctx.firstLineRowFont || defaultFirstLineRowFont;
-  const otherLineRowFont = ctx.otherLineRowFont || defaultOtherLineRowFont;
-  if (index === 0) {
-    return `${firstLineRowFont}\n${macro(ctx, node)}`;
-  } else if (index === 1) {
-    return `${otherLineRowFont}\n${macro(ctx, node)}`;
-  } else {
-    return macro(ctx, node);
-  }
+  return macro(ctx, node);
 }

--- a/packages/rebber/src/types/tableRow.js
+++ b/packages/rebber/src/types/tableRow.js
@@ -6,23 +6,11 @@ const defaultMacro = (ctx, node) => {
   const parsed = []
   node.children.map((n, index) => parsed.push(one(ctx, n, index, node)))
   const line = parsed.join(' & ')
-  return `${line} \\\\ \\hline\n`
+  return `${line} \\\\\n`
 }
-
-const defaultFirstLineRowFont = '\\rowfont[c]{\\bfseries}'
-const defaultOtherLineRowFont = '\\rowfont[l]{}'
 
 /* Stringify a tableRow `node`. */
 function tableRow (ctx, node, index) {
   const macro = ctx.tableRow || defaultMacro
-  const firstLineRowFont = ctx.firstLineRowFont || defaultFirstLineRowFont
-  const otherLineRowFont = ctx.otherLineRowFont || defaultOtherLineRowFont
-
-  if (index === 0) {
-    return `${firstLineRowFont}\n${macro(ctx, node)}`
-  } else if (index === 1) {
-    return `${otherLineRowFont}\n${macro(ctx, node)}`
-  } else {
-    return macro(ctx, node)
-  }
+  return macro(ctx, node)
 }

--- a/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/latex-suite.test.js.snap
@@ -561,35 +561,29 @@ exports[`mix-3 1`] = `
 `;
 
 exports[`mix-4 1`] = `
-"\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Sub & Headings & \\\\abbr{ABBR}{abbreviation} \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} column spanning &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{zdstblr}
 \\\\captionof{table}{The new table \\\\abbr{ABBR}{abbreviation} \\\\textsuperscript{\\\\protect\\\\footnotemark[1]} with \\\\keys{CTRL} + \\\\keys{S}}
 
 
 
 \\\\footnotetext[1]{a foot}
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-title & image \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & image \\\\\\\\
+space & \\\\image{https://i.ytimg.com/vi/lt0WQ8JzLz4/maxresdefault.jpg}[space] \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 2 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-title & code \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\ \\\\hline
-block & \\\\hyperref[appendix-1]{Annexe de code 1} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+title & code \\\\\\\\
+inline & \\\\CodeInline{inline} br \\\\endgraf \\\\CodeInline{inline} \\\\\\\\
+block & \\\\hyperref[appendix-1]{Annexe de code 1} \\\\\\\\
+\\\\end{zdstblr}
 
 
 \\\\begin{appendices}
@@ -737,22 +731,18 @@ a
 `;
 
 exports[`table 1`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-1 & 2 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2 \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-1 & 2 & 3 \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-1 & 2 \\\\\\\\ \\\\hline
-1 & 2 & 3 \\\\\\\\ \\\\hline
-1 & 2 & 3 \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+1 & 2 & 3 \\\\\\\\
+1 & 2 \\\\\\\\
+1 & 2 & 3 \\\\\\\\
+1 & 2 & 3 \\\\\\\\
+\\\\end{zdstblr}"
 `;

--- a/packages/zmarkdown/__tests__/__snapshots__/legacy-suite.test.js.snap
+++ b/packages/zmarkdown/__tests__/__snapshots__/legacy-suite.test.js.snap
@@ -3277,72 +3277,58 @@ Content Cell | Content Cell
 `;
 
 exports[`extensions renders tables.txt 2`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-First Header & Second Header \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+"\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First Header & Second Header \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-First Header & Second Header \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First Header & Second Header \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-Item & Value \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Computer & \\\\$1600 \\\\\\\\ \\\\hline
-Phone & \\\\$12 \\\\\\\\ \\\\hline
-Pipe & \\\\$1 \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Item & Value \\\\\\\\
+Computer & \\\\$1600 \\\\\\\\
+Phone & \\\\$12 \\\\\\\\
+Pipe & \\\\$1 \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-Function name & Description \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\CodeInline{help()} & Display the help window. \\\\\\\\ \\\\hline
-\\\\CodeInline{destroy()} & \\\\textbf{Destroy your computer!} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+Function name & Description \\\\\\\\
+\\\\CodeInline{help()} & Display the help window. \\\\\\\\
+\\\\CodeInline{destroy()} & \\\\textbf{Destroy your computer!} \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-foo & bar & baz \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
- & Q &  \\\\\\\\ \\\\hline
-W &  & W \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+foo & bar & baz \\\\\\\\
+ & Q &  \\\\\\\\
+W &  & W \\\\\\\\
+\\\\end{zdstblr}
 
 
 Three spaces in front of a table:
 
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-First Header & Second Header \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First Header & Second Header \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-First Header & Second Header \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-Content Cell & Content Cell \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+First Header & Second Header \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+Content Cell & Content Cell \\\\\\\\
+\\\\end{zdstblr}
 
 
 Four spaces is a code block:
@@ -3382,13 +3368,11 @@ exports[`extensions renders tables-2.txt 1`] = `
 `;
 
 exports[`extensions renders tables-2.txt 2`] = `
-"\\\\begin{longtabu} spread 0pt {|X[-1]|X[-1]|X[-1]|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-foo & bar & baz \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Q \\\\\\\\ \\\\hline
-W &  & W \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+"\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+foo & bar & baz \\\\\\\\
+Q \\\\\\\\
+W &  & W \\\\\\\\
+\\\\end{zdstblr}"
 `;
 
 exports[`heading-shift shifts before range 1`] = `"<h1 id=\\"should-be-h1\\">should be h1<a aria-hidden=\\"true\\" tabindex=\\"-1\\" href=\\"#should-be-h1\\"><span class=\\"icon icon-link\\"></span></a></h1>"`;
@@ -6567,138 +6551,112 @@ exports[`zds renders grid_tables.txt 2`] = `
 \\\\levelTwoTitle{Basic example}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Table Headings}} & Here \\\\\\\\ \\\\hline
-Sub & Headings & Too \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{cell \\\\endgraf spans \\\\endgraf rows}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{column spanning}} \\\\\\\\ \\\\cline{2-3}
- & normal & cell \\\\\\\\ \\\\hline
-multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs}}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=2,row{1,2}={font=\\\\bfseries}}
+\\\\SetCell[c=2]{l} Table Headings &  & Here \\\\\\\\
+Sub & Headings & Too \\\\\\\\
+\\\\SetCell[r=2]{l} cell \\\\endgraf spans \\\\endgraf rows & \\\\SetCell[c=2]{l} column spanning &  \\\\\\\\
+ & normal & cell \\\\\\\\
+multi \\\\endgraf line \\\\endgraf \\\\endgraf cells \\\\endgraf too & \\\\SetCell[c=2]{l} cells can be \\\\endgraf \\\\textit{formatted} \\\\endgraf \\\\textbf{paragraphs} &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & B & C \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\cline{2-3}
- & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & B & C \\\\\\\\
+\\\\SetCell[r=2]{l} D & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+ & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\cline{2-3}
-\\\\rowfont[l]{}
- & C & D \\\\\\\\ \\\\cline{2-3}
- & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[r=3]{l} A & \\\\SetCell[c=2]{l} B &  \\\\\\\\
+ & C & D \\\\\\\\
+ & \\\\SetCell[c=2]{l} E &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 3 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & C & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} \\\\\\\\ \\\\cline{1-2}
-E &  \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[c=3]{l} A &  &  \\\\\\\\
+\\\\SetCell[r=2]{l} B & C & \\\\SetCell[r=2]{l} D \\\\\\\\
+E &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{D}} & E \\\\\\\\ \\\\cline{1-1}
-\\\\rowfont[l]{}
-F &  \\\\\\\\ \\\\hline
-\\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{G}} & H \\\\\\\\ \\\\cline{2-2}
- & I \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1]}}
+\\\\SetCell[r=4]{l} C & \\\\SetCell[r=2]{l} D & E \\\\\\\\
+F &  \\\\\\\\
+\\\\SetCell[r=2]{l} G & H \\\\\\\\
+ & I \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 3 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\cline{1-2}
-\\\\rowfont[l]{}
-D &  \\\\\\\\ \\\\cline{1-2}
-E & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{F}} &  \\\\\\\\ \\\\cline{1-2}
-G &  \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1]}}
+A & \\\\SetCell[r=2]{l} B & \\\\SetCell[r=4]{l} C \\\\\\\\
+D &  \\\\\\\\
+E & \\\\SetCell[r=2]{l} F &  \\\\\\\\
+G &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{E}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\hline
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[c=2]{l} E &  & \\\\SetCell[c=2]{l} F &  \\\\\\\\
+\\\\SetCell[c=4]{l} G &  &  &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[c=4]{l} A &  &  &  \\\\\\\\
+\\\\SetCell[c=2]{l} B &  & \\\\SetCell[c=2]{l} C &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{A}} & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{B}} & C & D & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{E}} & \\\\multirow{3}{*}{\\\\parbox{\\\\linewidth}{F}} \\\\\\\\ \\\\cline{1-5}
-\\\\rowfont[l]{}
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{G}} &  \\\\\\\\ \\\\cline{1-5}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 6 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{H}} &  \\\\\\\\ \\\\hline
-\\\\multicolumn{6}{|m{\\\\dimexpr(\\\\linewidth) * 6 / 6 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{I}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[r=3]{l} A & \\\\SetCell[r=2]{l} B & C & D & \\\\SetCell[r=2]{l} E & \\\\SetCell[r=3]{l} F \\\\\\\\
+\\\\SetCell[c=2]{l} G &  &  \\\\\\\\
+\\\\SetCell[c=4]{l} H &  &  &  &  \\\\\\\\
+\\\\SetCell[c=6]{l} I &  &  &  &  &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 7 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & \\\\multicolumn{6}{|m{\\\\dimexpr(\\\\linewidth) * 6 / 7 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{C}} & \\\\multirow{4}{*}{\\\\parbox{\\\\linewidth}{\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\cline{1-1}
-\\\\rowfont[l]{\\\\bfseries}
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{H}} \\\\\\\\ \\\\hline
-\\\\end{longtabu}}} \\\\\\\\ \\\\hline
- &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
- &  &  &  &  &  \\\\\\\\ \\\\cline{1-1}
- &  &  &  &  &  \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=1,row{1}={font=\\\\bfseries}}
+A & \\\\SetCell[c=6]{l} B &  &  &  &  &  \\\\\\\\
+\\\\SetCell[r=4]{l} C & \\\\SetCell[r=4]{l} \\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+D & E & F & G \\\\\\\\
+\\\\SetCell[c=4]{l} H &  &  &  \\\\\\\\
+\\\\end{zdstblr} &  &  &  &  &  \\\\\\\\
+ &  &  &  &  &  \\\\\\\\
+ &  &  &  &  &  \\\\\\\\
+ &  &  &  &  &  \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 18 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-H & \\\\multicolumn{16}{|m{\\\\dimexpr(\\\\linewidth) * 16 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} & He \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-Li & Be & \\\\multirow{2}{*}{\\\\parbox{\\\\linewidth}{}} & B & C & N & O & F & Ne \\\\\\\\ \\\\cline{1-2} \\\\cline{13-18}
-Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\ \\\\hline
-K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\ \\\\hline
-Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\ \\\\hline
-Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\ \\\\hline
-Fr & Ra & ACT & \\\\multicolumn{15}{|m{\\\\dimexpr(\\\\linewidth) * 15 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{18}{|m{\\\\dimexpr(\\\\linewidth) * 18 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Lanthanide}} & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\ \\\\hline
-\\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 18 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{Actinide}} & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+H & \\\\SetCell[c=16]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  & He \\\\\\\\
+Li & Be & \\\\SetCell[r=2]{l}  &  &  &  &  &  &  &  &  &  & B & C & N & O & F & Ne \\\\\\\\
+Na & Mg &  &  &  &  &  &  &  &  &  &  & Al & Si & P & S & Cl & Ar \\\\\\\\
+K & Ca & Sc & Ti & V & Cr & Mn & Fe & Co & Ni & Cu & Zn & Ga & Ge & As & Se & Br & Kr \\\\\\\\
+Rb & Sr & Y & Zr & Nb & Mo & Tc & Ru & Rh & Pd & Ag & Cd & In & Sn & Sb & Te & I & Xe \\\\\\\\
+Cs & Ba & LAN & Hf & Ta & W & Re & Os & Ir & Pt & Au & Hg & Tl & Pb & Bi & Po & At & Rn \\\\\\\\
+Fr & Ra & ACT & \\\\SetCell[c=15]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=18]{l}  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  &  \\\\\\\\
+\\\\SetCell[c=3]{l} Lanthanide &  &  & La & Ce & Pr & Nd & Pm & Sm & Eu & Gd & Tb & Dy & Ho & Er & Tm & Yb & Lu \\\\\\\\
+\\\\SetCell[c=3]{l} Actinide &  &  & Ac & Th & Pa & U & Np & Pu & Am & Cm & Bk & Cf & Es & Fm & Md & No & Lw \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{zdstblr}
 
 
 Text at the end
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1]}}
+A \\\\\\\\
+\\\\end{zdstblr}
 
 
 Text at the
@@ -6712,40 +6670,32 @@ In this examples, the second row should always be a full-cell
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{A}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+\\\\SetCell[c=4]{l} A &  &  &  \\\\\\\\
+\\\\SetCell[c=4]{l} B | C &  &  &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & \\\\multicolumn{3}{|m{\\\\dimexpr(\\\\linewidth) * 3 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{}} \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
-\\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{D   E}} & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & \\\\SetCell[c=3]{l}  &  &  \\\\\\\\
+\\\\SetCell[c=4]{l} B | C &  &  &  \\\\\\\\
+\\\\SetCell[c=2]{l} D   E &  & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B | C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[c=4]{l} B | C &  &  &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 4 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
-A & B & C & D \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-\\\\multicolumn{4}{|m{\\\\dimexpr(\\\\linewidth) * 4 / 4 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{B  | C}} \\\\\\\\ \\\\hline
-D & E & F & G \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]}}
+A & B & C & D \\\\\\\\
+\\\\SetCell[c=4]{l} B  | C &  &  &  \\\\\\\\
+D & E & F & G \\\\\\\\
+\\\\end{zdstblr}
 
 
 \\\\levelTwoTitle{Failing example}
@@ -6779,23 +6729,20 @@ D & E & F & G \\\\\\\\ \\\\hline
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 1 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
- \\\\\\\\ \\\\hline
-\\\\end{longtabu}
+\\\\begin{zdstblr}{colspec={X[-1]}}
+ \\\\\\\\
+\\\\end{zdstblr}
 
 
 Bug \\\\#107
 
 
 
-\\\\begin{longtabu}{|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|m{\\\\dimexpr(\\\\linewidth) / 6 - 2 * \\\\tabcolsep}|} \\\\hline
-\\\\rowfont[l]{\\\\bfseries}
- & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{case1}} & \\\\multicolumn{2}{|m{\\\\dimexpr(\\\\linewidth) * 2 / 6 - 2 * \\\\tabcolsep}|}{\\\\parbox{\\\\linewidth}{case2}} & case3 \\\\\\\\ \\\\hline
- & case4 & case5 & case6 & case7 &  \\\\\\\\ \\\\hline
-\\\\rowfont[l]{}
-X & X & X & X & X & X \\\\\\\\ \\\\hline
-\\\\end{longtabu}"
+\\\\begin{zdstblr}{colspec={X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1] X[-1]},rowhead=2,row{1,2}={font=\\\\bfseries}}
+ & \\\\SetCell[c=2]{l} case1 &  & \\\\SetCell[c=2]{l} case2 &  & case3 \\\\\\\\
+ & case4 & case5 & case6 & case7 &  \\\\\\\\
+X & X & X & X & X & X \\\\\\\\
+\\\\end{zdstblr}"
 `;
 
 exports[`zds renders kbd.txt 1`] = `

--- a/packages/zmarkdown/config/latex/index.js
+++ b/packages/zmarkdown/config/latex/index.js
@@ -91,6 +91,7 @@ const rebberConfig = {
     image: (node) => `\\image{${node.url}}`
   },
   firstLineRowFont: '\\rowfont[l]{\\bfseries}',
+  tableEnvName: 'zdstblr',
   figure: {
     image: (_1, _2, caption, extra) => `\\image{${extra.url}}${caption ? `[${caption}]` : ''}\n`
   },


### PR DESCRIPTION
Fixes #463 
Fixes #498 

Implement a new table system based on `tabularray` for LaTeX rendering, to solve some bugs and make tables work with TeXLive >2020.
This PR will require changes on the template (I will open a PR in the upcoming days), do not merge until they are done.

I am expecting this PR, even after careful reviewing (which I intend to do), to raise some new bugs in ZMarkdown. It will likely require some bugfix versions before being stable.