### PR TITLE
[zmarkdown] Fix getting processus status in Munin controller

### DIFF
--- a/packages/zmarkdown/server/controllers/munin.js
+++ b/packages/zmarkdown/server/controllers/munin.js
@@ -109,7 +109,7 @@ module.exports = isConfig => (req, res) => {
       }
 
       const data = {
-        status:          status[proc.pm2_env.status] || 3,
+        status:          proc.pm2_env.status in status ? status[proc.pm2_env.status] : 3,
         memory:          proc.monit.memory,
         cpu:             proc.monit.cpu,
         event_loop_lag:  loopLag || 'U',


### PR DESCRIPTION
Since status `online` is coded as `0`, `0` was evaluated as `false` and thus the fallback value `3` was taken. Now, we use a ternary operator to test if the status is in the dictionnary to map to a number.

The concerned URL is http://localhost:27272/munin/status.