### PR TITLE
[zmarkdown] Set graph_vlabel for processus status in Munin controller

### DIFF
--- a/packages/zmarkdown/server/controllers/munin.js
+++ b/packages/zmarkdown/server/controllers/munin.js
@@ -7,7 +7,8 @@ module.exports = isConfig => (req, res) => {
     status: {
       graph: [
         'graph_title Process Status',
-        'graph_vlabel',
+        'graph_vlabel Status (0=online, 1=stopped, 2=errored)',
+        'graph_args --lower-limit 0 --upper-limit 3',
       ],
       fields: (name) => [
         `${name}.label ${name}`,


### PR DESCRIPTION
Otherwise Munin complains:
```
[WARNING] 1 lines had errors while 8 lines were correct in data from 'config zmd_status'
```
The part of the label `0=online, 1=stopped, 2=errored` could be generated automatically from the `status` object, but that's would maybe be over-engineered (and I don't know how to do it properly!).

I also added some property to the graph.

Here is how it looks:
![zmd_status-day](https://github.com/zestedesavoir/zmarkdown/assets/5911232/14f65ed4-7911-4f38-a1bd-d0691dc09e77)

The concerned URL is http://127.0.0.1:27272/munin/config/status.
