### PR TITLE
fix: fix webpack 5 config for live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ Currently, all the plugins provided only work for remark versions **lesser than*
 
 This project uses [Jest][jest] for testing. It is recommended to use the locally installed version using `npx`, and run Jest in watch mode when developing `npx jest --watch --notify` (`--notify` sends desktop notifications when tests run).
 
-### Development
-
-Read [`packages/zmarkdown/README.md`](zmarkdown-dev)
-
 ### Useful commands
 
 * `npm run test` : tests all packages.

--- a/README.md
+++ b/README.md
@@ -166,4 +166,3 @@ This project uses [Jest][jest] for testing. It is recommended to use the locally
 [typographic-colon]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/typographic-colon#typographic-colon--
 [typographic-permille]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/typographic-permille#typographic-permille--
 [zmarkdown]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/zmarkdown#zmarkdown--
-[zmarkdown-dev]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/zmarkdown#dev-build

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Currently, all the plugins provided only work for remark versions **lesser than*
 
 This project uses [Jest][jest] for testing. It is recommended to use the locally installed version using `npx`, and run Jest in watch mode when developing `npx jest --watch --notify` (`--notify` sends desktop notifications when tests run).
 
+### Development
+
+1. `npm run build-demo`
+1. Open `packages/zmarkdown/public/index.html` in your browser
+
 ### Useful commands
 
 * `npm run test` : tests all packages.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ This project uses [Jest][jest] for testing. It is recommended to use the locally
 
 ### Development
 
-1. `npm run build-demo`
-1. Open `packages/zmarkdown/public/index.html` in your browser
+Read [`packages/zmarkdown/README.md`](zmarkdown-dev)
 
 ### Useful commands
 
@@ -171,3 +170,4 @@ This project uses [Jest][jest] for testing. It is recommended to use the locally
 [typographic-colon]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/typographic-colon#typographic-colon--
 [typographic-permille]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/typographic-permille#typographic-permille--
 [zmarkdown]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/zmarkdown#zmarkdown--
+[zmarkdown-dev]: https://github.com/zestedesavoir/zmarkdown/tree/master/packages/zmarkdown#dev-build

--- a/packages/zmarkdown/package.json
+++ b/packages/zmarkdown/package.json
@@ -49,6 +49,7 @@
     "katex": "0.11.1",
     "md-attr-parser": "^1.3.0",
     "pm2": "^4.4.1",
+    "process": "^0.11.10",
     "rebber": "file:../rebber",
     "rebber-plugins": "file:../rebber-plugins",
     "rehype-autolink-headings": "^4.0.0",

--- a/packages/zmarkdown/package.json
+++ b/packages/zmarkdown/package.json
@@ -30,7 +30,7 @@
     "watch": "jest --watch",
     "server": "pm2 start -f server/index.js -i 3 --max-memory-restart 150M",
     "stop": "pm2 kill",
-    "watch:client": "cross-env NODE_ENV=development webpack --watch --info-verbosity=verbose",
+    "watch:client": "cross-env NODE_ENV=development webpack --watch",
     "release": "webpack"
   },
   "engines": {

--- a/packages/zmarkdown/webpack.config.js
+++ b/packages/zmarkdown/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const path = require('path')
 
 const mode = process.env.NODE_ENV ? process.env.NODE_ENV : 'production'
@@ -22,6 +23,11 @@ const defaultConf = {
       },
     ],
   },
+  plugins: [
+    new webpack.ProvidePlugin({
+      process: 'process/browser',
+    }),
+  ],
 }
 
 const makeExportObject = (type) => {

--- a/packages/zmarkdown/webpack.config.js
+++ b/packages/zmarkdown/webpack.config.js
@@ -1,4 +1,4 @@
-const webpack = require('webpack');
+const webpack = require('webpack')
 const path = require('path')
 
 const mode = process.env.NODE_ENV ? process.env.NODE_ENV : 'production'


### PR DESCRIPTION
Fix #494 

# Test

1. `npm run build-demo`
2. Open `packages/zmarkdown/public/index.html`